### PR TITLE
(SIMP-271) Don't restart httpd when CRL fetched

### DIFF
--- a/build/pupmod-pupmod.spec
+++ b/build/pupmod-pupmod.spec
@@ -1,7 +1,7 @@
 Summary: Puppet Management Puppet Module
 Name: pupmod-pupmod
 Version: 6.0.0
-Release: 17
+Release: 18
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -63,6 +63,10 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Mon Jun 17 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.0-18
+- Remove the legacy code that restarted httpd when the Puppet CRL was
+  downloaded.
+
 * Tue May 05 2015 Jacob Gingrich <jacob.gingrich@onyxpoint.com> - 6.0.0-17
 - Enabled the puppetserver service
 

--- a/templates/commands/crl_download.erb
+++ b/templates/commands/crl_download.erb
@@ -2,4 +2,4 @@
   t_ssldir = @vardir + @ssldir.gsub('$vardir','')
   t_ca_server = @ca_server.gsub('$server',@puppet_server)
 -%>
-/usr/bin/curl -sS --cert <%= t_ssldir %>/certs/<%= @trusted['certname'] %>.pem --key <%= t_ssldir %>/private_keys/<%= @trusted['certname'] %>.pem -k -o <%= t_ssldir %>/crl.pem -H "Accept: s" https://<%= t_ca_server %>:<%= @ca_port %>/production/certificate_revocation_list/ca && /sbin/service httpd reload
+/usr/bin/curl -sS --cert <%= t_ssldir %>/certs/<%= @trusted['certname'] %>.pem --key <%= t_ssldir %>/private_keys/<%= @trusted['certname'] %>.pem -k -o <%= t_ssldir %>/crl.pem -H "Accept: s" https://<%= t_ca_server %>:<%= @ca_port %>/production/certificate_revocation_list/ca


### PR DESCRIPTION
The CRL download code used to restart after downloading the Puppet CRL.
This should not be done (and probably should not have been done then!).

SIMP-271 #close #comment Fix legacy CRL + httpd restart