### PR TITLE
(SIMP-353) Enable FIPS

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -10,6 +10,7 @@ fixtures:
     augeasproviders_puppet: "git://github.com/simp/augeasproviders_puppet"
     common: "git://github.com/simp/pupmod-simp-common"
     concat: "git://github.com/simp/pupmod-simp-concat"
+    functions: "git://github.com/simp/pupmod-simp-functions"
     inifile: "git://github.com/simp/puppetlabs-inifile"
     iptables: "git://github.com/simp/pupmod-simp-iptables"
     logrotate: "git://github.com/simp/pupmod-simp-logrotate"

--- a/build/pupmod-pupmod.spec
+++ b/build/pupmod-pupmod.spec
@@ -1,7 +1,7 @@
 Summary: Puppet Management Puppet Module
 Name: pupmod-pupmod
 Version: 6.0.0
-Release: 18
+Release: 19
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -63,6 +63,9 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Thu Sep 17 2015 Kendall Moore <kmoore@keywcorp.com> - 6.0.0-19
+- Ensure keylength is set to 2048 in puppet.conf if FIPS mode is enabled.
+
 * Mon Jun 17 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.0-18
 - Remove the legacy code that restarted httpd when the Puppet CRL was
   downloaded.

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -353,6 +353,25 @@ class pupmod::master (
     notify  => Service[$service]
   }
 
+  # For now, FIPS compliance does not include 4096 bit keys. If FIPS is enabled,
+  # set the key length to 2048.
+  $fips_enabled_on_system = defined('$::fips_enabled') ? { true => $::fips_enabled, default => false }
+  $fips_enabled_in_hiera = hiera('use_fips')
+
+  if $fips_enabled_on_system or $fips_enabled_in_hiera {
+    $l_keylength = '2048'
+  }
+  else {
+    $l_keylength = '4096'
+  }
+
+  pupmod::conf { 'keylength':
+    section => ['master'],
+    setting => 'keylength',
+    value   => $l_keylength,
+    notify  => Service[$service]
+  }
+
   pupmod::conf { 'freeze_main':
     setting => 'freeze_main',
     # This is hard set for now until we can ensure that this works in all

--- a/spec/classes/master_spec.rb
+++ b/spec/classes/master_spec.rb
@@ -22,7 +22,8 @@ describe 'pupmod::master' do
       :trusted => { 'certname' => 'spec.test' },
       :uid_min => '500',
       :operatingsystemrelease => '6',
-      :osfamily => 'RedHat'
+      :osfamily => 'RedHat',
+      :use_fips => true
     },
     "RHEL 7" => {
       :apache_version => '2.4',
@@ -44,7 +45,8 @@ describe 'pupmod::master' do
       :trusted => { 'certname' => 'spec.test' },
       :uid_min => '500',
       :operatingsystemrelease => '7',
-      :osfamily => 'RedHat'
+      :osfamily => 'RedHat',
+      :use_fips => true
     }
   }
 

--- a/spec/fixtures/hieradata/default.yaml
+++ b/spec/fixtures/hieradata/default.yaml
@@ -2,3 +2,4 @@
 pupmod::puppet_server: '1.2.3.4'
 apache::rsync_server: '127.0.0.1'
 apache::ssl::client_nets: '127.0.0.1/32'
+use_fips: true


### PR DESCRIPTION
Ensure that the keylength variable is always set to 2048 if FIPS is enabled in
the master's puppet.conf

SIMP-353 #comment Set a reasonable default for keylength in puppet.conf
