### PR TITLE
(SIMP-353) Freshen up spec tests + use_fips logic

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--fail-fast

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,71 @@
 ---
 language: ruby
 cache: bundler
+bundler_args: --without development system_tests
+before_install: rm Gemfile.lock || true
 rvm:
-    - 1.8.7
-    - 1.9.3
-    - 2.0.0
-    - 2.2.1
-install: bundle install
+#  - 1.8.7  # bombs out on mime-types
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - 2.2.1
 script:
     - 'bundle exec rake validate'
     - 'bundle exec rake lint'
     - 'bundle exec rake spec'
+# NOTE: `:environmentpath` was not supported before Puppet 3.5
+env:
+  global:
+    - STRICT_VARIABLES=yes
+    - TRUSTED_NODE_DATA=yes
+  matrix:
+    - PUPPET_VERSION="~> 3.5.0"
+    - PUPPET_VERSION="~> 3.6.0"
+    - PUPPET_VERSION="~> 3.7.0"
+    - PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 3.8.0"
+    - PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 4.0.0"
+    - PUPPET_VERSION="~> 4.1.0"
+    - PUPPET_VERSION="~> 4.2.0"
+
 matrix:
-    allow_failures:
-        - rvm: 1.8.7
-        - rvm: 2.2.1
+  fast_finish: true
+  allow_failures:
+    - rvm: 1.8.7
+    - rvm: 2.1.0
+    - rvm: 2.2.1
+    - env: PUPPET_VERSION="~> 3.5.0"
+    - env: PUPPET_VERSION="~> 3.6.0"
+    - env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.1.0"
+    - env: PUPPET_VERSION="~> 4.2.0"
+
+  exclude:
+  # Ruby 1.8.7
+  # - Ruby 1.8.7 & Puppet 4.X is impossibru
+
+  # - simp-rake-helpers deps currently break between 1.8.7 and 3.X
+  # - Currently there is Gemfile logic testing for TRAVIS to avoid this.
+  # - For Ruby 1.8.7, testing earliest and latest 3.X is sufficient.
+
+  # Ruby 1.9.3
+  - rvm: 1.9.3
+    env: PUPPET_VERSION="~> 2.7.0"
+
+  # Ruby 2.0.0
+  - rvm: 2.0.0
+    env: PUPPET_VERSION="~> 2.7.0"
+
+  # Ruby 2.1.0
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.6.0"
+
+  # Ruby 2.2.1
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.6.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-# Environment variables:
+# Variables:
 #
 # SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
 # PUPPET_VERSION   | specifies the version of the puppet gem to load
@@ -7,17 +7,47 @@ gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[,
 
 gem_sources.each { |gem_source| source gem_source }
 
+group :test do
+  gem "rake"
+  gem 'puppet', puppetversion
+  gem "rspec", '< 3.2.0'
+  gem "rspec-puppet"
+  gem "puppetlabs_spec_helper"
+  gem "metadata-json-lint"
+  gem "simp-rspec-puppet-facts"
 
-gem 'puppet', puppetversion
-gem 'puppet-lint'
-gem 'puppetlabs_spec_helper'
-gem 'puppet_module_spec_helper'
-gem 'simp-rake-helpers'
+  # dependency hacks:
+  gem "fog-google", '~> 0.0.9' # 0.1 dropped support for ruby 1.9
 
-group :debug do
-    gem 'pry'
-    gem 'pry-doc'
-    gem 'rspec'
-    gem 'mocha'
-    gem 'metadata-json-lint'
+  # simp-rake-helpers does not suport puppet 2.7.X
+  if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&
+      # simp-rake-helpers and ruby 1.8.7 bomb Travis tests
+      # TODO: fix upstream deps (parallel in simp-rake-helpers)
+      RUBY_VERSION.sub(/\.\d+$/,'') != '1.8'
+    gem 'simp-rake-helpers'
+  end
 end
+
+group :development do
+  gem "travis"
+  gem "travis-lint"
+  gem "vagrant-wrapper"
+  gem "puppet-blacksmith"
+  gem "guard-rake"
+  gem 'pry'
+  gem 'pry-doc'
+end
+
+group :system_tests do
+  gem 'beaker'
+  gem 'beaker-rspec'
+
+  # 1.0.5 introduces FIPS-first acc tests
+  gem 'simp-beaker-helpers', '>= 1.0.5'
+
+  # dependency hacks:
+  # NOTE: Workaround because net-ssh 2.10 is busting beaker
+  # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
+  gem 'net-ssh', '~> 2.9.0'
+end
+

--- a/build/pupmod-pupmod.spec
+++ b/build/pupmod-pupmod.spec
@@ -1,7 +1,7 @@
 Summary: Puppet Management Puppet Module
 Name: pupmod-pupmod
 Version: 6.0.0
-Release: 19
+Release: 20
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -63,10 +63,13 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Wed Nov 04 2015 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.0.0-20
+- Improved logic for  defaults
+
 * Thu Sep 17 2015 Kendall Moore <kmoore@keywcorp.com> - 6.0.0-19
 - Ensure keylength is set to 2048 in puppet.conf if FIPS mode is enabled.
 
-* Mon Jun 17 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.0-18
+* Wed Jun 17 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.0-18
 - Remove the legacy code that restarted httpd when the Puppet CRL was
   downloaded.
 
@@ -199,7 +202,7 @@ fi
   site and, therefore, the name of the file in /etc/httpd/conf.d. This caused a
   conflict on upgrade.
 
-* Thu Sep 24 2013 Kendall Moore <kmoore@keywcorp.com> - 5.0.0-0
+* Tue Sep 24 2013 Kendall Moore <kmoore@keywcorp.com> - 5.0.0-0
 - Require puppet 3.X and puppet-server 3.X because of an upgrade to use
   hiera instead of extdata.
 - Updated the config.ru and apache_passenger templates as well as the passenger::add_site

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,7 +48,7 @@
 #
 # [*certname*]
 # Type: String
-# Default: $::trusted['certname']
+# Default: $::fqdn
 # The puppet environment name of the system.
 #
 # See http://docs.puppetlabs.com/references/latest/configuration.html for
@@ -196,33 +196,34 @@
 # * Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class pupmod (
-  $ca_port = hiera('puppet::ca_port','8141'),
-  $ca_server = hiera('puppet::ca','$server'),
-  $puppet_server = hiera('puppet::server',"puppet.${::domain}"),
-  $auditd_support = true,
+  $ca_port              = hiera('puppet::ca_port','8141'),
+  $ca_server            = hiera('puppet::ca','$server'),
+  $puppet_server        = hiera('puppet::server',"puppet.${::domain}"),
+  $auditd_support       = true,
   $ca_crl_pull_interval = '2',
-  $certname = $::trusted['certname'],
-  $classfile = '$vardir/classes.txt',
-  $confdir = '/etc/puppet',
-  $configtimeout = '120',
-  $daemonize = false,
-  $digest_algorithm = 'sha256',
+  $certname             = $::fqdn,
+  $classfile            = '$vardir/classes.txt',
+  $confdir              = '/etc/puppet',
+  $configtimeout        = '120',
+  $daemonize            = false,
+  $digest_algorithm     = 'sha256',
   $enable_puppet_master = false,
-  $environmentpath = '/etc/puppet/environments',
-  $listen = false,
-  $localconfig = '$vardir/localconfig',
-  $logdir = '/var/log/puppet',
-  $masterport = '8140',
-  $report = false,
-  $rundir = '/var/run/puppet',
-  $runinterval = '1800',
-  $splay = false,
-  $splaylimit = '',
-  $srv_domain = $::domain,
-  $ssldir = '$vardir/ssl',
-  $syslogfacility = 'local6',
-  $use_srv_records = false,
-  $vardir = '/var/lib/puppet'
+  $environmentpath      = '/etc/puppet/environments',
+  $listen               = false,
+  $localconfig          = '$vardir/localconfig',
+  $logdir               = '/var/log/puppet',
+  $masterport           = '8140',
+  $report               = false,
+  $rundir               = '/var/run/puppet',
+  $runinterval          = '1800',
+  $splay                = false,
+  $splaylimit           = '',
+  $srv_domain           = $::domain,
+  $ssldir               = '$vardir/ssl',
+  $syslogfacility       = 'local6',
+  $use_srv_records      = false,
+  $vardir               = '/var/lib/puppet',
+  $use_fips             = defined('$::fips_enabled') ? { true  => str2bool($::fips_enabled), default => hiera('use_fips', false) }
 ) {
 
   $l_crl_pull_minute = ip_to_cron(1)
@@ -422,7 +423,6 @@ class pupmod (
   else {
     $puppet_agent_sebool = 'puppetagent_manage_all_files'
   }
-
   if $::selinux_current_mode and $::selinux_current_mode != 'disabled' {
     selboolean { $puppet_agent_sebool :
       persistent => true,

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,57 @@
+{
+  "name":    "simp-pupmod",
+  "version": "5.0.0",
+  "author":  "SIMP",
+  "summary": "A puppet module to manage puppet",
+  "license": "Apache-2.0",
+  "source":  "https://github.com/simp/pupmod-simp-pupmod",
+  "project_page": "https://github.com/simp/pupmod-simp-pupmod",
+  "issues_url":   "https://simp-project.atlassian.net",
+  "tags": [ "simp", "ci", "pupmod" ],
+  "dependencies": [
+    {
+      "name": "puppetlabs-stdlib",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp-iptables",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp-logrotate",
+      "version_requirement": ">= 4.1.0-2"
+    },
+    {
+      "name": "simp-simplib",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp-apache",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp-pki",
+      "version_requirement": ">= 4.1.0-4"
+    },
+    {
+      "name": "simp-tcpwrappers",
+      "version_requirement": ">= 3.0.0-2"
+    }
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ]
+}

--- a/spec/classes/agent/cron_spec.rb
+++ b/spec/classes/agent/cron_spec.rb
@@ -1,105 +1,60 @@
 require 'spec_helper'
 
 describe 'pupmod::agent::cron' do
-  base_facts = {
-    "RHEL 6" => {
-      :apache_version => '2.2',
-      :fqdn => 'spec.test',
-      :grub_version => '0.97',
-      :hardwaremodel => 'x86_64',
-      :init_systems => ['sysv','rc','upstart'],
-      :interfaces => 'lo,eth0',
-      :ipaddress => '1.2.3.4',
-      :ipaddress_eth0 => '1.2.3.4',
-      :ipaddress_lo => '127.0.0.1',
-      :lsbmajdistrelease => '6',
-      :operatingsystem => 'RedHat',
-      :operatingsystemmajrelease => '6',
-      :passenger_root => '/usr/lib/ruby/gems/1.8/gems/passenger',
-      :passenger_version => '4',
-      :processorcount => 4,
-      :selinux_current_mode => 'enabled',
-      :trusted => { 'certname' => 'spec.test' },
-      :uid_min => '500',
-      :operatingsystemrelease => '6',
-      :osfamily => 'RedHat'
-    },
-    "RHEL 7" => {
-      :apache_version => '2.4',
-      :fqdn => 'spec.test',
-      :grub_version => '2.02~beta2',
-      :hardwaremodel => 'x86_64',
-      :init_systems => ['sysv','rc','upstart'],
-      :ipaddress => '1.2.3.4',
-      :interfaces => 'lo,eth0',
-      :ipaddress_eth0 => '1.2.3.4',
-      :ipaddress_lo => '127.0.0.1',
-      :lsbmajdistrelease => '7',
-      :operatingsystem => 'RedHat',
-      :operatingsystemmajrelease => '7',
-      :passenger_root => '/usr/lib/ruby/gems/1.8/gems/passenger',
-      :processorcount => 4,
-      :passenger_version => '4',
-      :selinux_current_mode => 'enabled',
-      :trusted => { 'certname' => 'spec.test' },
-      :uid_min => '500',
-      :operatingsystemrelease => '7',
-      :osfamily => 'RedHat'
-    }
-  }
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:trusted_facts){{
+        'certname' => 'spec.test'
+      }}
+      let(:base_facts) {{
+        :ipaddress      => '1.2.3.4',
+        :ipaddress_eth0 => '1.2.3.4',
+      }}
+      let(:facts){
+        x = os_facts.merge(base_facts)
+        x[:trusted] = trusted_facts if Puppet.version < "4.0.0"
+        x
+      }
+      if Puppet.version >= "4.0.0"
+        let(:trusted_data){ trusted_facts }
+      end
 
-  shared_examples_for "a fact set cron" do
-    let(:params) {{ :interval => '60' }}
 
-    it do
-      should contain_cron('puppetagent').with({
-        'minute'    => ['10','40'],
-        'hour'      => '*',
-        'monthday'  => '*',
-        'month'     => '*',
-        'weekday'   => '*'
-      })
-    end
+      describe 'using general parameters' do
+        let(:params) {{ :interval => '60' }}
 
-    it { should create_class('pupmod::agent::cron') }
-    it { should contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/-gt 3600/) }
+        it { is_expected.to create_class('pupmod::agent::cron') }
+        it { is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/-gt 3600/) }
+        it { is_expected.to contain_cron('puppetagent').with({
+            'minute'    => ['10','40'],
+            'hour'      => '*',
+            'monthday'  => '*',
+            'month'     => '*',
+            'weekday'   => '*'
+        })}
 
-    context 'use_alternate_minute_base' do
-      let(:params) {{ :minute_base => 'foo' }}
+        context 'use_alternate_minute_base' do
+          let(:params) {{ :minute_base => 'foo' }}
+          it { is_expected.to contain_cron('puppetagent').with({
+              'minute'    => ['29','59'],
+              'hour'      => '*',
+              'monthday'  => '*',
+              'month'     => '*',
+              'weekday'   => '*'
+          })}
+        end
 
-      it do
-        should contain_cron('puppetagent').with({
-          'minute'    => ['29','59'],
-          'hour'      => '*',
-          'monthday'  => '*',
-          'month'     => '*',
-          'weekday'   => '*'
-        })
+        context 'set_max_age' do
+          let(:params) {{ :maxruntime => '10' }}
+          it { is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/-gt 600/) }
+        end
+
+        context 'too_short_max_age' do
+          let(:params) {{ :maxruntime => '1' }}
+          conf_timeout = Puppet.settings[:configtimeout]
+          it { is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/-gt #{conf_timeout}/) }
+        end
       end
     end
-
-    context 'set_max_age' do
-      let(:params) {{ :maxruntime => '10' }}
-
-      it { should contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/-gt 600/) }
-    end
-
-    context 'too_short_max_age' do
-      let(:params) {{ :maxruntime => '1' }}
-
-      conf_timeout = Puppet.settings[:configtimeout]
-
-      it { should contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/-gt #{conf_timeout}/) }
-    end
-  end
-
-  describe "RHEL 6" do
-    it_behaves_like "a fact set cron"
-    let(:facts) {base_facts['RHEL 6']}
-  end
-
-  describe "RHEL 7" do
-    it_behaves_like "a fact set cron"
-    let(:facts) {base_facts['RHEL 7']}
   end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,94 +1,54 @@
 require 'spec_helper'
 
 describe 'pupmod' do
-  base_facts = {
-    "RHEL 6" => {
-      :apache_version => '2.2',
-      :fqdn => 'spec.test',
-      :grub_version => '0.97',
-      :hardwaremodel => 'x86_64',
-      :init_systems => ['sysv','rc','upstart'],
-      :interfaces => 'lo,eth0',
-      :ipaddress => '1.2.3.4',
-      :ipaddress_eth0 => '1.2.3.4',
-      :ipaddress_lo => '127.0.0.1',
-      :lsbmajdistrelease => '6',
-      :operatingsystem => 'RedHat',
-      :operatingsystemmajrelease => '6',
-      :passenger_root => '/usr/lib/ruby/gems/1.8/gems/passenger',
-      :passenger_version => '4',
-      :processorcount => 4,
-      :selinux_current_mode => 'enabled',
-      :trusted => { 'certname' => 'spec.test' },
-      :uid_min => '500',
-      :operatingsystemrelease => '6',
-      :osfamily => 'RedHat'
-    },
-    "RHEL 7" => {
-      :apache_version => '2.4',
-      :fqdn => 'spec.test',
-      :grub_version => '2.02~beta2',
-      :hardwaremodel => 'x86_64',
-      :init_systems => ['sysv','rc','upstart'],
-      :interfaces => 'lo,eth0',
-      :ipaddress => '1.2.3.4',
-      :ipaddress_eth0 => '1.2.3.4',
-      :ipaddress_lo => '127.0.0.1',
-      :lsbmajdistrelease => '7',
-      :operatingsystem => 'RedHat',
-      :operatingsystemmajrelease => '7',
-      :passenger_root => '/usr/lib/ruby/gems/1.8/gems/passenger',
-      :processorcount => 4,
-      :passenger_version => '4',
-      :selinux_current_mode => 'enabled',
-      :trusted => { 'certname' => 'spec.test' },
-      :uid_min => '500',
-      :operatingsystemrelease => '7',
-      :osfamily => 'RedHat'
-    }
-  }
-
-  shared_examples_for "a fact set init" do
-    it { should create_class('pupmod') }
-    it { should compile.with_all_deps }
-    it { should contain_file('/etc/puppet/puppet.conf') }
-    it {
-      if facts[:operatingsystemmajrelease].to_i < 7 then
-        should contain_selboolean('puppet_manage_all_files')
-      else
-        should contain_selboolean('puppetagent_manage_all_files')
-      end
-    }
-    it { should_not create_class('pupmod::master') }
-
-    context 'with_selinux_disabled' do
-      facts = base_facts[superclass.superclass.description].dup
-      facts[:selinux_current_mode] = 'disabled'
-      let(:facts) {facts}
-
-      it {
-        if facts[:operatingsystemmajrelease].to_i < 7 then
-          should_not contain_selboolean('puppet_manage_all_files')
-        else
-          should_not contain_selboolean('puppetagent_manage_all_files')
-        end
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:trusted_facts){{
+        'certname' => 'spec.test'
+      }}
+      let(:base_facts) {{
+          :selinux_current_mode => 'enabled',
+          :selinux              => true,
+      }}
+      let(:facts){
+        x = os_facts.merge(base_facts)
+        x[:trusted] = trusted_facts if Puppet.version < "4.0.0"
+        x
       }
+      let(:trusted_data){ trusted_facts } if Puppet.version >= "4.0.0"
+
+      describe "with default parameters" do
+        it { is_expected.to create_class('pupmod') }
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_file('/etc/puppet/puppet.conf') }
+        it {
+          if facts[:operatingsystemmajrelease].to_i < 7
+            is_expected.to contain_selboolean('puppet_manage_all_files')
+          else
+            is_expected.to contain_selboolean('puppetagent_manage_all_files')
+          end
+        }
+        it { is_expected.not_to create_class('pupmod::master') }
+
+        context 'with_selinux_disabled' do
+          let(:base_facts) {{
+              :selinux_current_mode => 'disabled',
+              :selinux              => false,
+          }}
+
+          if os_facts[:operatingsystemmajrelease].to_i < 7 then
+            it { is_expected.not_to contain_selboolean('puppet_manage_all_files') }
+          else
+            it { is_expected.not_to contain_selboolean('puppetagent_manage_all_files') }
+          end
+        end
+
+        context 'with_master_enabled' do
+          let(:params) {{ :enable_puppet_master => true, }}
+
+          it { is_expected.to create_class('pupmod::master') }
+        end
+      end
     end
-
-    context 'with_master_enabled' do
-      let(:params) {{ :enable_puppet_master => true, }}
-
-      it { should create_class('pupmod::master') }
-    end
-  end
-
-  describe "RHEL 6" do
-    it_behaves_like "a fact set init"
-    let(:facts) {base_facts['RHEL 6']}
-  end
-
-  describe "RHEL 7" do
-    it_behaves_like "a fact set init"
-    let(:facts) {base_facts['RHEL 7']}
   end
 end

--- a/spec/classes/master/base_spec.rb
+++ b/spec/classes/master/base_spec.rb
@@ -1,66 +1,28 @@
 require 'spec_helper'
 
 describe 'pupmod::master::base' do
-  base_facts = {
-    "RHEL 6" => {
-      :apache_version => '2.2',
-      :fqdn => 'spec.test',
-      :grub_version => '0.97',
-      :hardwaremodel => 'x86_64',
-      :init_systems => ['sysv','rc','upstart'],
-      :interfaces => 'lo,eth0',
-      :ipaddress => '1.2.3.4',
-      :ipaddress_eth0 => '1.2.3.4',
-      :ipaddress_lo => '127.0.0.1',
-      :lsbmajdistrelease => '6',
-      :operatingsystem => 'RedHat',
-      :operatingsystemmajrelease => '6',
-      :passenger_root => '/usr/lib/ruby/gems/1.8/gems/passenger',
-      :passenger_version => '4',
-      :processorcount => 4,
-      :selinux_current_mode => 'enabled',
-      :trusted => { 'certname' => 'spec.test' },
-      :uid_min => '500',
-      :operatingsystemrelease => '6',
-      :osfamily => 'RedHat'
-    },
-    "RHEL 7" => {
-      :apache_version => '2.4',
-      :fqdn => 'spec.test',
-      :grub_version => '2.02~beta2',
-      :hardwaremodel => 'x86_64',
-      :init_systems => ['sysv','rc','upstart'],
-      :ipaddress => '1.2.3.4',
-      :interfaces => 'lo,eth0',
-      :ipaddress_eth0 => '1.2.3.4',
-      :ipaddress_lo => '127.0.0.1',
-      :lsbmajdistrelease => '7',
-      :operatingsystem => 'RedHat',
-      :operatingsystemmajrelease => '7',
-      :passenger_root => '/usr/lib/ruby/gems/1.8/gems/passenger',
-      :processorcount => 4,
-      :passenger_version => '4',
-      :selinux_current_mode => 'enabled',
-      :trusted => { 'certname' => 'spec.test' },
-      :uid_min => '500',
-      :operatingsystemrelease => '7',
-      :osfamily => 'RedHat'
-    }
-  }
+    on_supported_os.each do |os, os_facts|
+      context "on #{os}" do
+        let(:trusted_facts){{
+          'certname' => 'spec.test'
+        }}
+        let(:base_facts) {{
+          :processorcount => 4,
+        }}
+        let(:facts){
+          x = os_facts.merge(base_facts)
+          x[:trusted] = trusted_facts if Puppet.version < "4.0.0"
+          x
+        }
+        if Puppet.version >= "4.0.0"
+          let(:trusted_data){ trusted_facts }
+        end
 
-  shared_examples_for "a fact set base" do
-    it { should create_class('pupmod::master::base') }
-    it { should contain_user('puppet') }
-    it { should contain_group('puppet') }
-  end
-
-  describe "RHEL 6" do
-    it_behaves_like "a fact set base"
-    let(:facts) {base_facts['RHEL 6']}
-  end
-
-  describe "RHEL 7" do
-    it_behaves_like "a fact set base"
-    let(:facts) {base_facts['RHEL 7']}
+      describe 'with default parameters' do
+        it { is_expected.to create_class('pupmod::master::base') }
+        it { is_expected.to contain_user('puppet') }
+        it { is_expected.to contain_group('puppet') }
+      end
+    end
   end
 end

--- a/spec/classes/master/reports_spec.rb
+++ b/spec/classes/master/reports_spec.rb
@@ -1,24 +1,17 @@
 require 'spec_helper'
 
 describe 'pupmod::master::reports' do
-  base_facts = {
-    :operatingsystem => 'RedHat',
-    :lsbmajdistrelease => '6',
-    :hardwaremodel => 'x86_64',
-    :spec_title => description,
-    :ipaddress => '1.2.3.4',
-    :processorcount => 8,
-    :passenger_root => '/usr/lib/ruby/gems/1.8/gems/passenger',
-    :passenger_version => '4',
-    :trusted => { 'certname' => 'foo.bar.baz' },
-    :grub_version => '0.9',
-    :uid_min => '500',
-    :apache_version => '2.2',
-    :init_systems => ['sysv','rc','upstart'],
-    :osfamily => 'RedHat'
-  }
-
-  let(:facts) {base_facts}
-
-  it { should create_file('/etc/cron.daily/puppet_client_report_purge').with_content(/rm -f/) }
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:trusted_facts){{ 'certname' => 'spec.test' }}
+      let(:base_facts) {{ }}
+      let(:facts){
+        x = os_facts.merge(base_facts)
+        x[:trusted] = trusted_facts if Puppet.version < "4.0.0"
+        x
+      }
+      let(:trusted_data){ trusted_facts } if Puppet.version >= "4.0.0"
+      it { is_expected.to create_file('/etc/cron.daily/puppet_client_report_purge').with_content(/rm -f/) }
+    end
+  end
 end

--- a/spec/classes/master_spec.rb
+++ b/spec/classes/master_spec.rb
@@ -1,70 +1,35 @@
 require 'spec_helper'
 
 describe 'pupmod::master' do
-  base_facts = {
-    "RHEL 6" => {
-      :apache_version => '2.2',
-      :fqdn => 'spec.test',
-      :grub_version => '0.97',
-      :hardwaremodel => 'x86_64',
-      :init_systems => ['sysv','rc','upstart'],
-      :interfaces => 'lo,eth0',
-      :ipaddress => '1.2.3.4',
-      :ipaddress_eth0 => '1.2.3.4',
-      :ipaddress_lo => '127.0.0.1',
-      :lsbmajdistrelease => '6',
-      :operatingsystem => 'RedHat',
-      :operatingsystemmajrelease => '6',
-      :passenger_root => '/usr/lib/ruby/gems/1.8/gems/passenger',
-      :passenger_version => '4',
-      :processorcount => 4,
-      :selinux_current_mode => 'enabled',
-      :trusted => { 'certname' => 'spec.test' },
-      :uid_min => '500',
-      :operatingsystemrelease => '6',
-      :osfamily => 'RedHat',
-      :use_fips => true
-    },
-    "RHEL 7" => {
-      :apache_version => '2.4',
-      :fqdn => 'spec.test',
-      :grub_version => '2.02~beta2',
-      :hardwaremodel => 'x86_64',
-      :init_systems => ['sysv','rc','upstart'],
-      :ipaddress => '1.2.3.4',
-      :interfaces => 'lo,eth0',
-      :ipaddress_eth0 => '1.2.3.4',
-      :ipaddress_lo => '127.0.0.1',
-      :lsbmajdistrelease => '7',
-      :operatingsystem => 'RedHat',
-      :operatingsystemmajrelease => '7',
-      :passenger_root => '/usr/lib/ruby/gems/1.8/gems/passenger',
-      :processorcount => 4,
-      :passenger_version => '4',
-      :selinux_current_mode => 'enabled',
-      :trusted => { 'certname' => 'spec.test' },
-      :uid_min => '500',
-      :operatingsystemrelease => '7',
-      :osfamily => 'RedHat',
-      :use_fips => true
-    }
-  }
+    on_supported_os.each do |os, os_facts|
+      context "on #{os}" do
+        let(:trusted_facts){{
+          'certname' => 'spec.test'
+        }}
+        let(:base_facts) {{
+            :selinux_current_mode => 'enabled',
+            :selinux              => true,
+        }}
+        let(:facts){
+          x = os_facts.merge(base_facts)
+          x[:trusted] = trusted_facts if Puppet.version < "4.0.0"
+          x
+        }
+        if Puppet.version >= "4.0.0"
+          let(:trusted_data){ trusted_facts }
+        end
 
-  shared_examples_for "a fact set master" do
-    it { should compile.with_all_deps }
-    it { should create_class('apache') }
-    it { should create_class('pupmod') }
-    it { should create_class('pupmod::master') }
-    it { should create_class('pupmod::master::base') }
-  end
+      shared_examples_for "a fact set master" do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('apache') }
+        it { is_expected.to create_class('pupmod') }
+        it { is_expected.to create_class('pupmod::master') }
+        it { is_expected.to create_class('pupmod::master::base') }
+      end
 
-  describe "RHEL 6" do
-    it_behaves_like "a fact set master"
-    let(:facts) {base_facts['RHEL 6']}
-  end
-
-  describe "RHEL 7" do
-    it_behaves_like "a fact set master"
-    let(:facts) {base_facts['RHEL 7']}
+      describe "with default parameters" do
+        it_behaves_like "a fact set master"
+      end
+    end
   end
 end

--- a/spec/defines/master/autosign_spec.rb
+++ b/spec/defines/master/autosign_spec.rb
@@ -1,29 +1,17 @@
 require 'spec_helper'
 
 describe 'pupmod::master::autosign' do
-  base_facts = {
-    :operatingsystem => 'RedHat',
-    :lsbmajdistrelease => '6',
-    :hardwaremodel => 'x86_64',
-    :spec_title => description,
-    :ipaddress => '1.2.3.4',
-    :grub_version => '0.9',
-    :uid_min => '500',
-    :apache_version => '2.2',
-    :init_systems => ['sysv','rc','upstart']
-  }
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) {facts}
 
-  let(:facts) {base_facts}
-
-  context 'base' do
-    let(:title) { 'autosign_test' }
-
-    let(:params) {{ :entry => 'foo bar' }}
-
-    it do
-      should contain_concat_fragment("autosign+#{title}.autosign").with({
-        :content => "#{title}\n#{params[:entry]}\n"
-      })
+      context 'base' do
+        let(:title) { 'autosign_test' }
+        let(:params) {{ :entry => 'foo bar' }}
+        it { is_expected.to contain_concat_fragment("autosign+#{title}.autosign").with({
+            :content => "#{title}\n#{params[:entry]}\n"
+        })}
+      end
     end
   end
 end

--- a/spec/defines/master/fileserver_entry_spec.rb
+++ b/spec/defines/master/fileserver_entry_spec.rb
@@ -1,62 +1,60 @@
 require 'spec_helper'
 
 describe 'pupmod::master::fileserver_entry' do
-  base_facts = {
-    :operatingsystem => 'RedHat',
-    :lsbmajdistrelease => '6',
-    :hardwaremodel => 'x86_64',
-    :spec_title => description,
-    :ipaddress => '1.2.3.4',
-    :grub_version => '0.9',
-    :uid_min => '500',
-    :apache_version => '2.2',
-    :init_systems => ['sysv','rc','upstart']
-  }
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      base_facts = {
+        :operatingsystem => 'RedHat',
+        :lsbmajdistrelease => '6',
+        :hardwaremodel => 'x86_64',
+        :spec_title => description,
+        :ipaddress => '1.2.3.4',
+        :grub_version => '0.9',
+        :uid_min => '500',
+        :apache_version => '2.2',
+        :init_systems => ['sysv','rc','upstart']
+      }
 
-  let(:facts) {base_facts}
-  let(:title) { 'fileserver_entry_test' }
+      let(:facts) {base_facts}
+      let(:title) { 'fileserver_entry_test' }
 
-  context 'base' do
+      context 'base' do
+        let(:params) {{
+          :path => '/good/path',
+          :allow => ['foo.bar.baz']
+        }}
+        it { is_expected.to (
+            contain_concat_fragment("fileserver+fileserver_entry_test.fileserver")
+              .with_content(
+                %r|\[fileserver_entry_test\]\n\s*path /good/path\n\sallow foo.bar.baz\n*|
+        ))}
+      end
 
-    let(:params) {{
-      :path => '/good/path',
-      :allow => ['foo.bar.baz']
-    }}
+      context 'bad_path' do
+        let(:params) {{
+          :path  => 'bad_path',
+          :allow => ['foo.bar.baz']
+        }}
 
-    it do
-      should contain_concat_fragment("fileserver+#{title}.fileserver").with({
-        :content => "[#{title}]
- path #{params[:path]}
- allow #{params[:allow].first}
+        it do
+          expect {
+            is_expected.to contain_concat_fragment("fileserver+#{title}.fileserver")
+          }.to raise_error(Puppet::Error, /"#{params[:path]}" is not an absolute path/)
+        end
+      end
 
-"
-      })
-    end
-  end
+      context 'bad_allow' do
+        let(:params) {{
+          :path  => '/foo/bar',
+          :allow => 'foo.bar.baz'
+        }}
 
-  context 'bad_path' do
-    let(:params) {{
-      :path  => 'bad_path',
-      :allow => ['foo.bar.baz']
-    }}
-
-    it do
-      expect {
-        should contain_concat_fragment("fileserver+#{title}.fileserver")
-      }.to raise_error(Puppet::Error, /"#{params[:path]}" is not an absolute path/)
-    end
-  end
-
-  context 'bad_allow' do
-    let(:params) {{
-      :path  => '/foo/bar',
-      :allow => 'foo.bar.baz'
-    }}
-
-    it do
-      expect {
-        should contain_concat_fragment("fileserver+#{title}.fileserver")
-      }.to raise_error(Puppet::Error, /"#{params[:allow]}" is not an Array/)
+        it do
+          expect {
+            is_expected.to contain_concat_fragment("fileserver+#{title}.fileserver")
+          }.to raise_error(Puppet::Error, /"#{params[:allow]}" is not an Array/)
+        end
+      end
     end
   end
 end

--- a/templates/commands/crl_download.erb
+++ b/templates/commands/crl_download.erb
@@ -2,4 +2,4 @@
   t_ssldir = @vardir + @ssldir.gsub('$vardir','')
   t_ca_server = @ca_server.gsub('$server',@puppet_server)
 -%>
-/usr/bin/curl -sS --cert <%= t_ssldir %>/certs/<%= @trusted['certname'] %>.pem --key <%= t_ssldir %>/private_keys/<%= @trusted['certname'] %>.pem -k -o <%= t_ssldir %>/crl.pem -H "Accept: s" https://<%= t_ca_server %>:<%= @ca_port %>/production/certificate_revocation_list/ca
+/usr/bin/curl -sS --cert <%= t_ssldir %>/certs/<%= @certname %>.pem --key <%= t_ssldir %>/private_keys/<%= @certname %>.pem -k -o <%= t_ssldir %>/crl.pem -H "Accept: s" https://<%= t_ca_server %>:<%= @ca_port %>/production/certificate_revocation_list/ca


### PR DESCRIPTION
Before this commit, the use_fips logic required two variables and could
not be influenced with a parameter.  The module was also missing some
support files and used old versions of others.   This commit updates the
use_fips logic and modernizes the module structure to include better
support files (e.g., Gemfile, metadata.json) and current spec test
practices (e.g., expectations, simp-rspec-puppet-facts).

SIMP-353 #comment updated use_fips logic,
SIMP-353 #comment added pupmod::use_fips parameter
SIMP-353 #comment freshened up module practices (files, tests)
SIMP-353 #close