### PR TITLE
(SIMP-398) Eliminate all uses of lsb* facts

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,0 +1,4 @@
+--log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
+--relative
+--no-class_inherits_from_params_class-check
+--no-80chars-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,27 @@
 ---
 language: ruby
+sudo: false
 cache: bundler
+before_script:
+  - bundle
 bundler_args: --without development system_tests
 before_install: rm Gemfile.lock || true
+script:
+  - bundle exec rake test
+notifications:
+  email: false
 rvm:
-#  - 1.8.7  # bombs out on mime-types
+  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.0
   - 2.2.1
-script:
-    - 'bundle exec rake validate'
-    - 'bundle exec rake lint'
-    - 'bundle exec rake spec'
-# NOTE: `:environmentpath` was not supported before Puppet 3.5
 env:
   global:
     - STRICT_VARIABLES=yes
     - TRUSTED_NODE_DATA=yes
   matrix:
+  # NOTE: `:environmentpath` was not supported before Puppet 3.5
     - PUPPET_VERSION="~> 3.5.0"
     - PUPPET_VERSION="~> 3.6.0"
     - PUPPET_VERSION="~> 3.7.0"
@@ -28,7 +31,6 @@ env:
     - PUPPET_VERSION="~> 4.0.0"
     - PUPPET_VERSION="~> 4.1.0"
     - PUPPET_VERSION="~> 4.2.0"
-
 matrix:
   fast_finish: true
   allow_failures:
@@ -39,33 +41,50 @@ matrix:
     - env: PUPPET_VERSION="~> 3.6.0"
     - env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
     - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.0.0"
     - env: PUPPET_VERSION="~> 4.1.0"
     - env: PUPPET_VERSION="~> 4.2.0"
 
   exclude:
   # Ruby 1.8.7
   # - Ruby 1.8.7 & Puppet 4.X is impossibru
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.0.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.1.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.2.0"
 
   # - simp-rake-helpers deps currently break between 1.8.7 and 3.X
   # - Currently there is Gemfile logic testing for TRAVIS to avoid this.
   # - For Ruby 1.8.7, testing earliest and latest 3.X is sufficient.
-
-  # Ruby 1.9.3
-  - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 2.7.0"
-
-  # Ruby 2.0.0
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 2.7.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
 
   # Ruby 2.1.0
   - rvm: 2.1.0
     env: PUPPET_VERSION="~> 3.5.0"
   - rvm: 2.1.0
     env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.7.0"
 
   # Ruby 2.2.1
   - rvm: 2.2.1
     env: PUPPET_VERSION="~> 3.5.0"
   - rvm: 2.2.1
     env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,92 @@
+This module has grown over time based on a range of contributions from
+people using it. If you follow these contributing guidelines your patch
+will likely make it into a release a little quicker.
+
+
 ## Contributing
 
-Please refer to the main [SIMP Project Contributing Guide](https://github.com/NationalSecurityAgency/SIMP/blob/master/CONTRIBUTING.md)
-for details on contributing to this project.
+1. Fork the repo.
+
+2. Run the tests. We only take pull requests with passing tests, and
+   it's great to know that you have a clean slate.
+
+3. Add a test for your change. Only refactoring and documentation
+   changes require no new tests. If you are adding functionality
+   or fixing a bug, please add a test.
+
+4. Make the test pass.
+
+5. Push to your fork and submit a pull request.
+
+
+## Dependencies
+
+The testing and development tools have a bunch of dependencies,
+all managed by [Bundler](http://bundler.io/) according to the
+[Puppet support matrix](http://docs.puppetlabs.com/guides/platforms.html#ruby-versions).
+
+By default the tests use a baseline version of Puppet.
+
+If you have Ruby 2.x or want a specific version of Puppet,
+you must set an environment variable such as:
+
+    export PUPPET_VERSION="~> 3.2.0"
+
+Install the dependencies like so...
+
+    bundle install
+
+## Syntax and style
+
+The test suite will run [Puppet Lint](http://puppet-lint.com/) and
+[Puppet Syntax](https://github.com/gds-operations/puppet-syntax) to
+check various syntax and style things. You can run these locally with:
+
+    bundle exec rake lint
+    bundle exec rake syntax
+
+## Running the unit tests
+
+The unit test suite covers most of the code, as mentioned above please
+add tests if you're adding new functionality. If you've not used
+[rspec-puppet](http://rspec-puppet.com/) before then feel free to ask
+about how best to test your new feature. Running the test suite is done
+with:
+
+    bundle exec rake spec
+
+Note also you can run the syntax, style and unit tests in one go with:
+
+    bundle exec rake test
+
+### Automatically run the tests
+
+During development of your puppet module you might want to run your unit
+tests a couple of times. You can use the following command to automate
+running the unit tests on every change made in the manifests folder.
+
+    bundle exec guard
+
+## Integration tests
+
+The unit tests just check the code runs, not that it does exactly what
+we want on a real machine. For that we're using
+[Beaker](https://github.com/puppetlabs/beaker).
+
+Beaker fires up a new virtual machine (using Vagrant) and runs a series of
+simple tests against it after applying the module. You can run our
+Beaker tests with:
+
+    bundle exec rake acceptance
+
+This will use the host described in `spec/acceptance/nodeset/default.yml`
+by default. To run against another host, set the `BEAKER_set` environment
+variable to the name of a host described by a `.yml` file in the
+`nodeset` directory. For example, to run against CentOS 6.4:
+
+    BEAKER_set=centos-64-x64 bundle exec rake acceptance
+
+If you don't want to have to recreate the virtual machine every time you
+can use `BEAKER_destroy=no` and `BEAKER_provision=no`. On the first run you will
+at least need `BEAKER_provision` set to yes (the default). The Vagrantfile
+for the created virtual machines will be in `.vagrant/beaker_vagrant_files`.

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 #
 # SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
 # PUPPET_VERSION   | specifies the version of the puppet gem to load
-puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['~>3']
+puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : '~>3'
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
 gem_sources.each { |gem_source| source gem_source }
@@ -50,4 +50,3 @@ group :system_tests do
   # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
   gem 'net-ssh', '~> 2.9.0'
 end
-

--- a/Rakefile
+++ b/Rakefile
@@ -1,27 +1,68 @@
-#!/usr/bin/rake -T
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet/version'
+require 'puppet/vendor/semantic/lib/semantic' unless Puppet.version.to_f < 3.6
+require 'puppet-syntax/tasks/puppet-syntax'
+require 'puppet-lint/tasks/puppet-lint'
 
-# For playing nice with mock
-File.umask(027)
+# These gems aren't always present, for instance
+# on Travis with --without development
+begin
+  require 'puppet_blacksmith/rake_tasks'
+rescue LoadError
+end
 
-require 'simp/rake/pkg'
+
+# Lint & Syntax exclusions
+exclude_paths = [
+  "bundle/**/*",
+  "pkg/**/*",
+  "dist/**/*",
+  "vendor/**/*",
+  "spec/**/*",
+]
+PuppetSyntax.exclude_paths = exclude_paths
+
+# See: https://github.com/rodjek/puppet-lint/pull/397
+Rake::Task[:lint].clear
+PuppetLint.configuration.ignore_paths = exclude_paths
+PuppetLint::RakeTask.new :lint do |config|
+  config.ignore_paths = PuppetLint.configuration.ignore_paths
+end
 
 begin
-  require 'puppetlabs_spec_helper/rake_tasks'
+  require 'simp/rake/pkg'
+  Simp::Rake::Pkg.new( File.dirname( __FILE__ ) ) do | t |
+    t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
+  end
 rescue LoadError
-  puts "== WARNING: Gem puppetlabs_spec_helper not found, spec tests cannot be run! =="
+  puts "== WARNING: Gem simp-rake-helpers not found, pkg: tasks cannot be run! =="
 end
 
-# Lint Material
 begin
-  require 'puppet-lint/tasks/puppet-lint'
-
-  PuppetLint.configuration.send("disable_80chars")
-  PuppetLint.configuration.send("disable_variables_not_enclosed")
-  PuppetLint.configuration.send("disable_class_parameter_defaults")
+  require 'simp/rake/beaker'
+  Simp::Rake::Beaker.new( File.dirname( __FILE__ ) )
 rescue LoadError
-  puts "== WARNING: Gem puppet-lint not found, lint tests cannot be run! =="
+  # Ignoring this for now since all of these are currently convenience methods.
 end
 
-Simp::Rake::Pkg.new( File.dirname( __FILE__ ) ) do | t |
-  t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
+desc "Run acceptance tests"
+RSpec::Core::RakeTask.new(:acceptance) do |t|
+  t.pattern = 'spec/acceptance'
 end
+
+desc "Populate CONTRIBUTORS file"
+task :contributors do
+  system("git log --format='%aN' | sort -u > CONTRIBUTORS")
+end
+
+task :metadata do
+  sh "metadata-json-lint metadata.json"
+end
+
+desc "Run syntax, lint, and spec tests."
+task :test => [
+  :syntax,
+  :lint,
+  :spec,
+  :metadata,
+]

--- a/manifests/agent/cron.pp
+++ b/manifests/agent/cron.pp
@@ -105,6 +105,10 @@ class pupmod::agent::cron (
   $weekday = '*',
   $maxruntime = ''
   ) {
+  validate_integer($interval)
+  validate_string($minute_base)
+  validate_integer($runs_per_timeframe)
+  validate_integer($run_timeframe)
 
   include 'pupmod'
 
@@ -144,9 +148,4 @@ class pupmod::agent::cron (
     mode    => '0750',
     content => template('pupmod/usr/local/bin/puppetagent_cron.erb')
   }
-
-  validate_integer($interval)
-  validate_string($minute_base)
-  validate_integer($runs_per_timeframe)
-  validate_integer($run_timeframe)
 }

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -42,6 +42,9 @@ define pupmod::conf (
 ) {
   include '::pupmod'
 
+  validate_string($setting)
+  validate_array($section)
+
   $l_name = "${module_name}_${name}"
 
   ini_setting { $l_name:
@@ -51,7 +54,4 @@ define pupmod::conf (
     # This needs to be a string to take effect!
     value   => $value
   }
-
-  validate_string($setting)
-  validate_array($section)
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -226,6 +226,34 @@ class pupmod (
   $use_fips             = defined('$::fips_enabled') ? { true  => str2bool($::fips_enabled), default => hiera('use_fips', false) }
 ) {
 
+  validate_port($ca_port)
+  validate_string($ca_server)
+  validate_bool($auditd_support)
+  validate_integer($ca_crl_pull_interval)
+  validate_string($certname)
+  validate_re($classfile,'^(\$(?!/)|/).+')
+  validate_re($confdir,'^(\$(?!/)|/).+')
+  validate_integer($configtimeout)
+  validate_bool($daemonize)
+  validate_string($digest_algorithm)
+  validate_bool($enable_puppet_master)
+  validate_re($environmentpath,'^(\$(?!/)|/).+')
+  validate_bool($listen)
+  validate_re($localconfig,'^(\$(?!/)|/).+')
+  validate_re($logdir,'^(\$(?!/)|/).+')
+  validate_port($masterport)
+  validate_bool($report)
+  validate_re($rundir,'^(\$(?!/)|/).+')
+  validate_integer($runinterval)
+  validate_bool($splay)
+  if !empty($splaylimit) { validate_integer($splaylimit) }
+  validate_string($srv_domain)
+  validate_net_list($srv_domain)
+  validate_re($ssldir,'^(\$(?!/)|/).+')
+  validate_string($syslogfacility)
+  validate_bool($use_srv_records)
+  validate_absolute_path($vardir)
+
   $l_crl_pull_minute = ip_to_cron(1)
   $l_crl_pull_hour = ip_to_cron($ca_crl_pull_interval,24)
 
@@ -429,32 +457,4 @@ class pupmod (
       value      => 'on'
     }
   }
-
-  validate_port($ca_port)
-  validate_string($ca_server)
-  validate_bool($auditd_support)
-  validate_integer($ca_crl_pull_interval)
-  validate_string($certname)
-  validate_re($classfile,'^(\$(?!/)|/).+')
-  validate_re($confdir,'^(\$(?!/)|/).+')
-  validate_integer($configtimeout)
-  validate_bool($daemonize)
-  validate_string($digest_algorithm)
-  validate_bool($enable_puppet_master)
-  validate_re($environmentpath,'^(\$(?!/)|/).+')
-  validate_bool($listen)
-  validate_re($localconfig,'^(\$(?!/)|/).+')
-  validate_re($logdir,'^(\$(?!/)|/).+')
-  validate_port($masterport)
-  validate_bool($report)
-  validate_re($rundir,'^(\$(?!/)|/).+')
-  validate_integer($runinterval)
-  validate_bool($splay)
-  if !empty($splaylimit) { validate_integer($splaylimit) }
-  validate_string($srv_domain)
-  validate_net_list($srv_domain)
-  validate_re($ssldir,'^(\$(?!/)|/).+')
-  validate_string($syslogfacility)
-  validate_bool($use_srv_records)
-  validate_absolute_path($vardir)
 }

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -203,14 +203,9 @@ class pupmod::master (
   $syslog_message_format = '%logger[%thread]: %msg',
   $log_level = 'WARN'
 ) {
-  $service = 'puppetserver'
-  $l_client_nets = nets2cidr($client_nets)
-  $l_confdir = $::pupmod::confdir
-
   validate_net_list($bind_address)
   validate_net_list($ca_bind_address)
   validate_port($ca_port)
-  validate_net_list($l_client_nets)
   validate_re($ca_ttl,'^\d+y$')
   validate_bool($daemonize)
   validate_bool($enable_ca)
@@ -233,6 +228,11 @@ class pupmod::master (
   validate_string($syslog_facility)
   validate_string($syslog_message_format)
   validate_array_member($log_level,['TRACE','DEBUG','INFO','WARN','ERROR','OFF'])
+
+  $service = 'puppetserver'
+  $l_client_nets = nets2cidr($client_nets)
+  validate_net_list($l_client_nets)
+  $l_confdir = $::pupmod::confdir
 
   include '::apache'
   include '::pupmod'

--- a/manifests/master/autosign.pp
+++ b/manifests/master/autosign.pp
@@ -19,9 +19,9 @@ define pupmod::master::autosign (
   $entry
 ) {
 
-  $l_name = inline_template("<%= '$name'.gsub('/','_') %>")
+  $l_name = inline_template("<%= '${name}'.gsub('/','_') %>")
 
-  concat_fragment { "autosign+$l_name.autosign":
-    content => "$name\n$entry\n"
+  concat_fragment { "autosign+${l_name}.autosign":
+    content => "${name}\n${entry}\n"
   }
 }

--- a/manifests/master/fileserver_entry.pp
+++ b/manifests/master/fileserver_entry.pp
@@ -24,13 +24,13 @@ define pupmod::master::fileserver_entry (
     $allow,
     $path
 ) {
-  $l_name = inline_template("<%= '$name'.gsub('/','_') %>")
-
   # Validation first to appease rspec
   validate_array($allow)
   validate_absolute_path($path)
 
-  concat_fragment { "fileserver+$l_name.fileserver":
+  $l_name = inline_template("<%= '${name}'.gsub('/','_') %>")
+
+  concat_fragment { "fileserver+${l_name}.fileserver":
     content => template('pupmod/content/fileserver.erb')
   }
 

--- a/manifests/master/reports.pp
+++ b/manifests/master/reports.pp
@@ -31,6 +31,9 @@ class pupmod::master::reports (
   $purge_keep_days = '7',
   $purge_verbose = false
 ) {
+  validate_bool($purge)
+  validate_integer($purge_keep_days)
+  validate_bool($purge_verbose)
 
   if $purge {
     if $purge_verbose {
@@ -48,8 +51,4 @@ class pupmod::master::reports (
       content => "#!/bin/sh\n${l_purge_script}"
     }
   }
-
-  validate_bool($purge)
-  validate_integer($purge_keep_days)
-  validate_bool($purge_verbose)
 }

--- a/manifests/master/sysconfig.pp
+++ b/manifests/master/sysconfig.pp
@@ -73,6 +73,14 @@ class pupmod::master::sysconfig (
   $service_stop_retries = '60',
   $start_timeout = '120'
 ) {
+  validate_absolute_path($java_bin)
+  validate_re($java_start_memory,'^\d+(g|k|m)$')
+  validate_re($java_max_memory,'^\d+(g|k|m|%)$')
+  validate_re($java_max_perm_size,'^\d+(g|k|m)$')
+  if !empty($java_temp_dir) { validate_absolute_path($java_temp_dir) }
+  validate_array($extra_java_args)
+  validate_integer($service_stop_retries)
+  validate_integer($start_timeout)
 
   if empty($java_temp_dir) {
     $l_java_temp_dir = "${::pupmod::vardir}/pserver_tmp"
@@ -95,13 +103,4 @@ class pupmod::master::sysconfig (
     content => template('pupmod/etc/sysconfig/puppetserver.erb'),
     notify  => Service[$::pupmod::master::service]
   }
-
-  validate_absolute_path($java_bin)
-  validate_re($java_start_memory,'^\d+(g|k|m)$')
-  validate_re($java_max_memory,'^\d+(g|k|m|%)$')
-  validate_re($java_max_perm_size,'^\d+(g|k|m)$')
-  if !empty($java_temp_dir) { validate_absolute_path($java_temp_dir) }
-  validate_array($extra_java_args)
-  validate_integer($service_stop_retries)
-  validate_integer($start_timeout)
 }

--- a/spec/defines/master/fileserver_entry_spec.rb
+++ b/spec/defines/master/fileserver_entry_spec.rb
@@ -5,7 +5,7 @@ describe 'pupmod::master::fileserver_entry' do
     context "on #{os}" do
       base_facts = {
         :operatingsystem => 'RedHat',
-        :lsbmajdistrelease => '6',
+        :operatingsystemmajrelease => '6',
         :hardwaremodel => 'x86_64',
         :spec_title => description,
         :ipaddress => '1.2.3.4',


### PR DESCRIPTION
This commit replaces all `lsb*` facts with their (package-independent)
`operatingsystem*` counterparts.

Also:
- normalized common static module assets
- corrected lint errors
- moved parameter validations to the top of each class

SIMP-677 #close
SIMP-398 #comment updated `pupmod-simp-pupmod`
SIMP-667 #comment updated `pupmod-simp-pupmod`
