### PR TITLE
(SIMP-392) Bug fixes found during testing

### DIFF
--- a/build/pupmod-pupmod.spec
+++ b/build/pupmod-pupmod.spec
@@ -1,7 +1,7 @@
 Summary: Puppet Management Puppet Module
 Name: pupmod-pupmod
 Version: 6.0.0
-Release: 22
+Release: 23
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -17,9 +17,9 @@ Requires: pupmod-augeasproviders_grub >= 1.0.2
 Requires: pupmod-augeasproviders_puppet >= 1.0.2
 Buildarch: noarch
 Requires: simp-bootstrap >= 4.2.0
-Obsoletes: pupmod-pupmod-test
+Obsoletes: pupmod-pupmod-test >= 0.0.1
 
-Prefix: /etc/puppet/environments/simp/modules
+Prefix: %{_sysconfdir}/puppet/environments/simp/modules
 
 %description
 This unfortunately named Puppet module provides the capability to configure both
@@ -55,14 +55,18 @@ mkdir -p %{buildroot}/%{prefix}/pupmod
 %post
 #!/bin/sh
 
-if [ -d %{prefix}/pupmod/plugins ]; then
-  /bin/mv %{prefix}/pupmod/plugins %{prefix}/pupmod/plugins.bak
-fi
-
 %postun
 # Post uninstall stuff
 
 %changelog
+* Thu Dec 24 2015 Trevor Vaughan <tvaughahn@onyxpoint.com> - 6.0.0-23
+- Fixed minor logic errors
+- Now have configuration changes notify Service['puppetserver'] instead of the
+  more efficient Exec. This gets around a race condition when the service is
+  restarted and the exec fires before the service has fully restarted.
+- Fixed issues with the puppetserver_* helper scripts that surfaced due to
+  changes in the HTTP responses from the Puppet Server.
+
 * Fri Dec 04 2015 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.0.0-22
 - Replaced all 'lsb*' facts with their (package-independent)
   'operatingsystem*' counterparts.

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -232,7 +232,6 @@ class pupmod::master (
   $service = 'puppetserver'
   $l_client_nets = nets2cidr($client_nets)
   validate_net_list($l_client_nets)
-  $l_confdir = $::pupmod::confdir
 
   include '::apache'
   include '::pupmod'
@@ -240,6 +239,8 @@ class pupmod::master (
   include '::pupmod::master::reports'
   include '::pupmod::master::base'
   Class['::pupmod::master::sysconfig'] ~> Service[$service]
+
+  $l_confdir = $::pupmod::confdir
 
   file { '/etc/puppetserver':
     ensure => 'directory',

--- a/manifests/master/base.pp
+++ b/manifests/master/base.pp
@@ -10,13 +10,14 @@ class pupmod::master::base {
   include '::pupmod::master'
 
   $masterport = $::pupmod::master::masterport
+  $admin_api_mountpoint = $::pupmod::master::admin_api_mountpoint
 
   $auto_fragdir = fragmentdir('autosign')
   concat_build { 'autosign':
     quiet  => true,
     order  => ['*.autosign'],
     target => "${::pupmod::confdir}/autosign.conf",
-    notify => Exec['puppetserver_reload']
+    notify => Service[$::pupmod::master::service]
   }
 
   exec { 'puppetserver_reload':
@@ -68,7 +69,7 @@ class pupmod::master::base {
     path       => '^/node/([^/]+)$',
     path_regex => true,
     allow      => ['$1', $::fqdn],
-    notify     => Exec['puppetserver_reload']
+    notify     => Service[$::pupmod::master::service]
   }
 
   group { 'puppet':

--- a/manifests/master/sysconfig.pp
+++ b/manifests/master/sysconfig.pp
@@ -96,7 +96,7 @@ class pupmod::master::sysconfig (
     mode   => '0750'
   }
 
-  file { '/etc/sysconfig/puppetmaster':
+  file { '/etc/sysconfig/puppetserver':
     owner   => 'root',
     group   => 'root',
     mode    => '0640',

--- a/templates/usr/local/sbin/puppetserver_clear_environment_cache.erb
+++ b/templates/usr/local/sbin/puppetserver_clear_environment_cache.erb
@@ -1,3 +1,9 @@
 # A simple script for clearing the environment cache on the local server
 
-curl -s -i --cert `puppet config print hostcert` --key `puppet config print hostprivkey` --cacert `puppet config print localcacert` -X DELETE https://<%= @fqdn %>:<%= scope.lookupvar('::pupmod::masterport') %><%= scope.lookupvar('::pupmod::master::admin_api_mountpoint') %>/v1/environment-cache | grep -q 'HTTP 204: No Content'
+cert=`puppet config print hostcert`
+key=`puppet config print hostprivkey`
+cacert=`puppet config print localcacert`
+
+resp=`curl -o /dev/null -L -w "%{http_code}" -s -i --cert ${cert} --key ${key} --cacert ${cacert} -X DELETE https://<%= @fqdn %>:<%= @masterport %><%= @admin_api_mountpoint %>/v1/environment-cache`
+
+test "$resp" -eq '204'

--- a/templates/usr/local/sbin/puppetserver_reload.erb
+++ b/templates/usr/local/sbin/puppetserver_reload.erb
@@ -1,3 +1,9 @@
 # A simple script for reloading the Puppet Server JRuby instances
 
-curl -s -i --cert `puppet config print hostcert` --key `puppet config print hostprivkey` --cacert `puppet config print localcacert` -X DELETE https://<%= @fqdn %>:<%= scope.lookupvar('::pupmod::masterport') %><%= scope.lookupvar('::pupmod::master::admin_api_mountpoint') %>/v1/jruby-pool | grep -q 'HTTP 204: No Content'
+cert=`puppet config print hostcert`
+key=`puppet config print hostprivkey`
+cacert=`puppet config print localcacert`
+
+resp=`curl -o /dev/null -L -w "%{http_code}" -s -i --cert ${cert} --key ${key} --cacert ${cacert} -X DELETE https://<%= @fqdn %>:<%= @masterport %><%= @admin_api_mountpoint %>/v1/jruby-pool`
+
+test "$resp" -eq '204'


### PR DESCRIPTION
- Fixed minor logic errors
- Now have configuration changes notify Service['puppetserver'] instead of the
  more efficient Exec. This gets around a race condition when the service is
  restarted and the exec fires before the service has fully restarted.
- Fixed issues with the puppetserver_* helper scripts that surfaced due to
  changes in the HTTP responses from the Puppet Server.

SIMP-392 #comment Fixed issues found during testing