### PR TITLE
(SIMP-823) Update service subscribe hard coding

### DIFF
--- a/build/pupmod-pupmod.spec
+++ b/build/pupmod-pupmod.spec
@@ -1,7 +1,7 @@
 Summary: Puppet Management Puppet Module
 Name: pupmod-pupmod
 Version: 6.0.0
-Release: 23
+Release: 24
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -59,7 +59,11 @@ mkdir -p %{buildroot}/%{prefix}/pupmod
 # Post uninstall stuff
 
 %changelog
-* Thu Dec 24 2015 Trevor Vaughan <tvaughahn@onyxpoint.com> - 6.0.0-23
+* Wed Feb 24 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.0-24
+- Fix the subscribe on the Service['puppet'] resource to not be a hard coded
+  path.
+
+* Thu Dec 24 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.0-23
 - Fixed minor logic errors
 - Now have configuration changes notify Service['puppetserver'] instead of the
   more efficient Exec. This gets around a race condition when the service is

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -278,7 +278,7 @@ class pupmod (
       hasrestart => true,
       hasstatus  => false,
       status     => '/usr/bin/test `/bin/ps --no-headers -fC puppetd,"puppet agent" | /usr/bin/wc -l` -ge 1 -a ! `/bin/ps --no-headers -fC puppetd,"puppet agent" | /bin/grep -c "no-daemonize"` -ge 1',
-      subscribe  => File['/etc/puppet/puppet.conf']
+      subscribe  => File["${confdir}/puppet.conf"]
     }
   }
   else {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-pupmod",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "author":  "SIMP",
   "summary": "A puppet module to manage puppet",
   "license": "Apache-2.0",


### PR DESCRIPTION
The Puppet service was hard coded and needed to be pointing to
${confdir} instead.

SIMP-823 #close