### PR TITLE
(SIMP-1128) Limit heap size in Java

### DIFF
--- a/manifests/master/sysconfig.pp
+++ b/manifests/master/sysconfig.pp
@@ -66,7 +66,7 @@
 class pupmod::master::sysconfig (
   $java_bin = '/usr/bin/java',
   $java_start_memory = '2g',
-  $java_max_memory = '80%',
+  $java_max_memory = $::pupmod::params::java_max_memory,
   $java_max_perm_size = '256m',
   $java_temp_dir = '',
   $extra_java_args = [],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,15 @@
+# Class: pupmod::params
+#
+# A set of defaults for the 'pupmod' namespace
+#
+# $java_max_memory
+#   should not exceed 12G (SIMP-1128)
+#
+class pupmod::params {
+  if $::memorysize_mb >= '12000' {
+    $java_max_memory = '12G'
+  }
+  else {
+    $java_max_memory = '80%'
+  }
+}


### PR DESCRIPTION
Heap size should not exceed 12G.

SIMP-1128 #close
