### PR TITLE
(SIMP-1574) Fix Forge `haveged` dependency name

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Sep 28 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.0.6-0
+- Fix Forge `haveged` dependency name
+
 * Thu Jun 30 2016 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.5-0
 - Use_haveged is now a global catalyst.
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,16 +1,20 @@
 {
-  "name":    "simp-pupmod",
-  "version": "6.0.5",
-  "author":  "SIMP",
+  "name": "simp-pupmod",
+  "version": "6.0.6",
+  "author": "SIMP",
   "summary": "A puppet module to manage puppet",
   "license": "Apache-2.0",
-  "source":  "https://github.com/simp/pupmod-simp-pupmod",
+  "source": "https://github.com/simp/pupmod-simp-pupmod",
   "project_page": "https://github.com/simp/pupmod-simp-pupmod",
-  "issues_url":   "https://simp-project.atlassian.net",
-  "tags": [ "simp", "ci", "pupmod" ],
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "ci",
+    "pupmod"
+  ],
   "dependencies": [
     {
-      "name": "simp/puppet-haveged",
+      "name": "simp/haveged",
       "version_requirement": ">= 0.3.0 < 1.0.0"
     },
     {


### PR DESCRIPTION
`metadata.json` erroneously claimed `simp/puppet-haveged` as a
dependency, which causes a fatal error when pushing to the Forge.

This patch corrects the dependency name  to `simp/haveged`.

SIMP-1574 #comment fixed pupmod-simp-pupmod
