### PR TITLE
(SIMP-1675) pupmod::ssldir breaks auditd restart

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -167,7 +167,6 @@
 #
 # [*ssldir*]
 # Type: Path with optional permissions argument.
-# Default: $vardir/ssl
 # The path to the puppet ssl directory.
 #
 # See http://docs.puppetlabs.com/references/latest/configuration.html for
@@ -193,7 +192,6 @@
 #
 # [*vardir*]
 # Type: Absolute Path
-# Default: /var/lib/puppet
 #
 # The directory where puppet will store all of its 'variable' data.
 #
@@ -225,13 +223,13 @@ class pupmod (
   $splay                = false,
   $splaylimit           = '',
   $srv_domain           = $::domain,
-  $ssldir               = '$vardir/ssl',
+  $ssldir               = $::pupmod::params::ssldir,
   $syslogfacility       = 'local6',
   $use_srv_records      = false,
-  $vardir               = '/var/lib/puppet',
+  $vardir               = $::pupmod::params::vardir,
   $use_haveged          = defined('$::use_haveged') ? { true => getvar('::use_haveged'), default => hiera('use_haveged', true) },
   $use_fips             = defined('$::fips_enabled') ? { true  => str2bool($::fips_enabled), default => hiera('use_fips', false) }
-) {
+) inherits pupmod::params {
 
   validate_port($ca_port)
   validate_string($ca_server)
@@ -256,7 +254,7 @@ class pupmod (
   if !empty($splaylimit) { validate_integer($splaylimit) }
   validate_string($srv_domain)
   validate_net_list($srv_domain)
-  validate_re($ssldir,'^(\$(?!/)|/).+')
+  validate_absolute_path($ssldir)
   validate_string($syslogfacility)
   validate_bool($use_srv_records)
   validate_absolute_path($vardir)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,14 +2,21 @@
 #
 # A set of defaults for the 'pupmod' namespace
 #
+# [*vardir*]
+# Type: Absolute Path
+# Default: /var/lib/puppet
+#
 # $java_max_memory
 #   should not exceed 12G (SIMP-1128)
 #
-class pupmod::params {
+class pupmod::params (
+  $vardir               = '/var/lib/puppet'
+) {
   if ($::memorysize_mb * 0.8) >= 12000 {
     $java_max_memory = '12g'
   }
   else {
     $java_max_memory = '80%'
   }
+  $ssldir = "${vardir}/ssl"
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -5,10 +5,153 @@ describe 'pupmod' do
     context "on #{os}" do
       let(:facts) { facts }
 
-      context "with default parameters" do
+      describe "with default parameters" do
         it { is_expected.to create_class('pupmod') }
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_file('/etc/puppet/puppet.conf') }
+        it { is_expected.to contain_class('haveged') }
+        it { is_expected.to contain_cron('puppet_crl_pull').with_command(
+         %q{/usr/bin/curl -sS --cert /var/lib/puppet/ssl/certs/foo.example.com.pem --key /var/lib/puppet/ssl/private_keys/foo.example.com.pem -k -o /var/lib/puppet/ssl/crl.pem -H "Accept: s" https://1.2.3.4:8141/production/certificate_revocation_list/ca
+}) }
+
+        it { is_expected.to contain_cron('puppet_crl_pull').with_user('root') }
+        it { is_expected.to contain_class('pupmod::agent::cron') }
+        it { is_expected.to contain_pupmod__conf('agent_daemonize').with({
+          'section' => ['agent'],
+          'setting' => 'daemonize',
+          'value' => 'false'
+        }) }
+
+        it { is_expected.to contain_pupmod__conf('server').with({
+          'setting' => 'server',
+          'value' => '1.2.3.4'
+        }) }
+
+        it { is_expected.to contain_pupmod__conf('ca_server').with({
+          'setting' => 'ca_server',
+          'value' => '$server'
+        }) }
+
+        it { is_expected.to contain_pupmod__conf('masterport').with({
+          'setting' => 'masterport',
+          'value' => '8140'
+        }) }
+
+        it { is_expected.to contain_pupmod__conf('report').with({
+          'section' => ['agent'],
+          'setting' => 'report',
+          'value' => 'false'
+        }) }
+
+        it { is_expected.to contain_pupmod__conf('ca_port').with({
+          'setting' => 'ca_port',
+          'value' => '8141'
+        }) }
+
+        it { is_expected.to contain_pupmod__conf('splay').with({
+          'setting' => 'splay',
+          'value' => 'false'
+        }) }
+
+        it { is_expected.not_to contain_pupmod__conf('splaylimit') }
+        it { is_expected.to contain_pupmod__conf('syslogfacility').with({
+          'setting' => 'syslogfacility',
+          'value' => 'local6'
+        }) }
+
+        it { is_expected.to contain_pupmod__conf('srv_domain').with({
+          'setting' => 'srv_domain',
+          'value' => 'example.com'
+        }) }
+
+        it { is_expected.to contain_pupmod__conf('certname').with({
+          'setting' => 'certname',
+          'value' => 'foo.example.com'
+        }) }
+
+        it { is_expected.to contain_pupmod__conf('classfile').with({
+          'setting' => 'classfile',
+          'value' => '$vardir/classes.txt'
+        }) }
+
+        it { is_expected.to contain_pupmod__conf('confdir').with({
+          'setting' => 'confdir',
+          'value' => '/etc/puppet'
+        }) }
+
+        it { is_expected.to contain_pupmod__conf('configtimeout').with({
+          'setting' => 'configtimeout',
+          'value' => '120'
+        }) }
+
+        it { is_expected.to contain_pupmod__conf('localconfig').with({
+          'setting' => 'localconfig',
+          'value' => '$vardir/localconfig'
+        }) }
+
+        it { is_expected.to contain_pupmod__conf('logdir').with({
+          'setting' => 'logdir',
+          'value' => '/var/log/puppet'
+        }) }
+
+        it { is_expected.to contain_pupmod__conf('rundir').with({
+          'setting' => 'rundir',
+          'value' => '/var/run/puppet'
+        }) }
+
+        it { is_expected.to contain_pupmod__conf('runinterval').with({
+          'setting' => 'runinterval',
+          'value' => '1800'
+        }) }
+
+        it { is_expected.to contain_pupmod__conf('ssldir').with({
+          'setting' => 'ssldir',
+          'value' => '/var/lib/puppet/ssl'
+        }) }
+
+        it { is_expected.to contain_pupmod__conf('stringify_facts').with({
+          'setting' => 'stringify_facts',
+          'value' => 'false'
+        }) }
+
+        it { is_expected.to contain_pupmod__conf('digest_algorithm').with({
+          'setting' => 'digest_algorithm',
+          'value' => 'sha256'
+        }) }
+
+        it { is_expected.not_to create_class('pupmod::master') }
+        it { is_expected.to contain_class('auditd') }
+        it { is_expected.to contain_auditd__add_rules('puppet_master').with_content( %q{
+        -a always,exit -F dir=/etc/puppet -F uid!=puppet -p wa -k Puppet_Config
+        -a always,exit -F dir=/var/log/puppet -F uid!=puppet -p wa -k Puppet_Log
+        -a always,exit -F dir=/var/run/puppet -F uid!=puppet -p wa -k Puppet_Run
+        -a always,exit -F dir=/var/lib/puppet/ssl -F uid!=puppet -p wa -k Puppet_SSL
+      }) }
+
+        it { is_expected.to contain_file('/etc/puppet').with({
+          'ensure' => 'directory',
+          'owner'  => 'root',
+          'group'  => 'puppet',
+          'mode'   => '0640'
+        }) }
+
+        it { is_expected.to contain_file('/etc/puppet/puppet.conf').with({
+          'ensure' => 'file',
+          'owner'  => 'root',
+          'group'  => 'puppet',
+          'mode'   => '0640',
+          'audit'  => 'content'
+        }) }
+
+        it { is_expected.to contain_file('/etc/sysconfig/puppet').with({
+          'ensure'  => 'file',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'content' => "PUPPET_EXTRA_OPTS='--daemonize'\n"
+        }) }
+
+        it { is_expected.to contain_package('puppet').with_ensure('latest') }
+        it { is_expected.to contain_package('facter').with_ensure('latest') }
         it 'operatingsystem < 7' do
           if facts[:operatingsystemmajrelease].to_i < 7
             is_expected.to contain_selboolean('puppet_manage_all_files')
@@ -16,8 +159,6 @@ describe 'pupmod' do
             is_expected.to contain_selboolean('puppetagent_manage_all_files')
           end
         end
-        it { is_expected.not_to create_class('pupmod::master') }
-        it { is_expected.to contain_class('haveged') }
 
         context 'with_selinux_disabled' do
           let(:facts) {
@@ -33,28 +174,67 @@ describe 'pupmod' do
             it { is_expected.not_to contain_selboolean('puppetagent_manage_all_files') }
           end
         end
+      end
+
+      describe "with non-default parameters" do
+        context 'with use_haveged => false' do
+          let(:params) {{:use_haveged => false}}
+          it { is_expected.to_not contain_class('haveged') }
+        end
+
+        context 'with daemonize enabled' do
+          let(:params) {{:daemonize => true}}
+          it { is_expected.to contain_cron('puppetagent').with_ensure('absent') }
+          it { is_expected.to contain_service('puppet').with({
+            'ensure'     => 'running',
+            'enable'     => true,
+            'hasrestart' => true,
+            'hasstatus'  => false,
+            'status'     => '/usr/bin/test `/bin/ps --no-headers -fC puppetd,"puppet agent" | /usr/bin/wc -l` -ge 1 -a ! `/bin/ps --no-headers -fC puppetd,"puppet agent" | /bin/grep -c "no-daemonize"` -ge 1',
+            'subscribe'  => 'File[/etc/puppet/puppet.conf]'
+          }) }
+        end
 
         context 'with_master_enabled' do
           let(:params) {{ :enable_puppet_master => true, }}
-
           it { is_expected.to create_class('pupmod::master') }
         end
-      end
 
-      context 'with use_haveged => false' do
-        let(:params) {{:use_haveged => false}}
-        it { is_expected.to_not contain_class('haveged') }
-      end
+        context 'with auditd_support => false' do
+          let(:params) {{:auditd_support => false}}
+          it { is_expected.to_not contain_class('auditd') }
+          it { is_expected.to_not contain_auditd__add_rules('puppet_master') }
+        end
 
-      context 'with invalid input' do
-        let(:params) {{:use_haveged => 'invalid_input'}}
-        it 'with use_haveged as a string' do
-          expect {
-            is_expected.to compile
-          }.to raise_error(RSpec::Expectations::ExpectationNotMetError,/invalid_input" is not a boolean/)
+        context 'with non-empty splaylimit' do
+          let(:params) {{:splaylimit => '5'}}
+          it { is_expected.to contain_pupmod__conf('splaylimit').with({
+            'setting' => 'splaylimit',
+            'value' => '5'
+          }) }
         end
       end
 
+      describe 'with invalid input' do
+        [:ssldir, :vardir].each do |path|
+          context "with invalid #{path}" do
+            let(:params) {{path => 'relative/path'}}
+            it 'fails to compile' do
+              expect { is_expected.to compile
+              }.to raise_error(RSpec::Expectations::ExpectationNotMetError,%r{"relative/path" is not an absolute path})
+            end
+          end
+        end
+
+        context 'with invalid use_haveged' do
+          let(:params) {{:use_haveged => 'invalid_input'}}
+          it 'fails to compile' do
+            expect {
+              is_expected.to compile
+            }.to raise_error(RSpec::Expectations::ExpectationNotMetError,/invalid_input" is not a boolean/)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/classes/master_spec.rb
+++ b/spec/classes/master_spec.rb
@@ -4,12 +4,610 @@ describe 'pupmod::master' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts){ facts }
+      let(:pre_condition) { 'include "pupmod"' }
 
-      it { is_expected.to compile.with_all_deps }
-      it { is_expected.to create_class('apache') }
-      it { is_expected.to create_class('pupmod') }
-      it { is_expected.to create_class('pupmod::master') }
-      it { is_expected.to create_class('pupmod::master::base') }
+      describe "with default parameters" do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('apache') }
+        it { is_expected.to create_class('pupmod') }
+        it { is_expected.to create_class('pupmod::master::sysconfig') }
+        it { is_expected.to create_class('pupmod::master::reports') }
+        it { is_expected.to create_class('pupmod::master::base') }
+        it { is_expected.to contain_class('pupmod::master::sysconfig').that_comes_before('Service[puppetserver]') }
+        it { is_expected.to contain_file('/etc/puppetserver').with({
+          'ensure' => 'directory',
+          'owner'  => 'root',
+          'group'  => 'puppet',
+          'mode'   => '0640'
+        }) }
+
+        it { is_expected.to contain_file('/etc/puppetserver/conf.d').with({
+          'ensure' => 'directory',
+          'owner'  => 'root',
+          'group'  => 'puppet',
+          'mode'   => '0640'
+        }) }
+
+        it { is_expected.to contain_file('/etc/puppetserver/bootstrap.cfg').with({
+          'ensure'  => 'file',
+          'owner'   => 'root',
+          'group'   => 'puppet',
+          'mode'    => '0640',
+          'content' => %q{# This file managed by Puppet
+# Any changes will be removed on the next run
+puppetlabs.services.request-handler.request-handler-service/request-handler-service
+puppetlabs.services.jruby.jruby-puppet-service/jruby-puppet-pooled-service
+puppetlabs.services.puppet-profiler.puppet-profiler-service/puppet-profiler-service
+puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
+puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-service
+puppetlabs.services.config.puppet-server-config-service/puppet-server-config-service
+puppetlabs.services.master.master-service/master-service
+puppetlabs.services.version.version-check-service/version-check-service
+puppetlabs.services.puppet-admin.puppet-admin-service/puppet-admin-service
+
+puppetlabs.services.ca.certificate-authority-service/certificate-authority-service
+},
+          'require' => 'Package[puppetserver]',
+          'notify'  => 'Service[puppetserver]'
+        }) }
+
+        it { is_expected.to contain_file('/etc/puppetserver/logback.xml').with({
+          'ensure'  => 'file',
+          'owner'   => 'root',
+          'group'   => 'puppet',
+          'mode'    => '0640',
+          'content' => %q~<!--
+  This file managed by Puppet.
+  Any changes will be erased at the next run.
+-->
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d %-5p [%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="SYSLOG" class="ch.qos.logback.classic.net.SyslogAppender">
+      <syslogHost>localhost</syslogHost>
+      <facility>LOCAL6</facility>
+      <suffixPattern>%logger[%thread]: %msg</suffixPattern>
+      <throwableExcluded>true</throwableExcluded>
+    </appender>
+
+    <appender name="F1" class="ch.qos.logback.core.FileAppender">
+        <file>/var/log/puppetserver/puppetserver.log</file>
+        <append>true</append>
+        <encoder>
+            <pattern>%d %-5p [%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.eclipse.jetty" level="WARN"/>
+
+    <root level="WARN">
+        <appender-ref ref="SYSLOG"/>
+    </root>
+</configuration>
+~,
+          'require' => 'Package[puppetserver]',
+          'notify'  => 'Service[puppetserver]'
+        }) }
+
+        it { is_expected.to contain_file('/etc/puppetserver/conf.d/ca.conf').with({
+          'ensure'  => 'file',
+          'owner'   => 'root',
+          'group'   => 'puppet',
+          'mode'    => '0640',
+          'content' => %q~# This file managed by Puppet
+# Any changes will be removed on the next run
+
+# CA-related settings
+certificate-authority: {
+
+    # settings for the certificate_status HTTP endpoint
+    certificate-status: {
+
+        # this setting contains a list of client certnames who are whitelisted to
+        # have access to the certificate_status endpoint.  Any requests made to
+        # this endpoint that do not present a valid client cert mentioned in
+        # this list will be denied access.
+        client-whitelist: [foo.example.com]
+    }
+}
+~,
+          'require' => 'Package[puppetserver]',
+          'notify'  => 'Service[puppetserver]'
+        }) }
+
+        it { is_expected.to_not contain_file('/etc/puppetserver/conf.d/os-settings.conf') }
+        it { is_expected.to contain_file('/etc/puppetserver/conf.d/puppetserver.conf').with({
+          'ensure'  => 'file',
+          'owner'   => 'root',
+          'group'   => 'puppet',
+          'mode'    => '0640',
+          'content' => %q~# This file managed by Puppet
+# Any changes will be removed on the next run
+
+# configuration for the JRuby interpreters
+jruby-puppet: {
+    # This setting determines where JRuby will look for gems.  It is also
+    # used by the `puppetserver gem` command line tool.
+    gem-home: /var/lib/puppet/jruby-gems
+
+    # (optional) path to puppet conf dir; if not specified, will use the puppet default
+    master-conf-dir: /etc/puppet
+
+    # (optional) path to puppet var dir; if not specified, will use the puppet default
+    master-var-dir: /var/lib/puppet
+
+    # (optional) maximum number of JRuby instances to allow; defaults to <num-cpus>+2
+    max-active-instances: 3
+}
+
+# settings related to HTTP client requests made by Puppet Server
+http-client: {
+    # A list of acceptable protocols for making HTTP requests
+    ssl-protocols: [TLSv1,TLSv1.1,TLSv1.2]
+}
+
+# settings related to profiling the puppet Ruby code
+profiler: {
+    # enable or disable profiling for the Ruby code; defaults to 'false'.
+    enabled: false
+}
+
+# Settings related to the puppet-admin HTTP API
+puppet-admin: {
+    client-whitelist: [foo.example.com]
+}
+~,
+          'require' => 'Package[puppetserver]',
+          'notify'  => 'Service[puppetserver]'
+        }) }
+
+        it { is_expected.to contain_file('/etc/puppetserver/conf.d/web-routes.conf').with({
+          'ensure'  => 'file',
+          'owner'   => 'root',
+          'group'   => 'puppet',
+          'mode'    => '0640',
+          'content' => %q~# This file managed by Puppet
+# Any changes will be removed on the next run
+web-router-service: {
+    # These two should not be modified because the Puppet 3.x agent expects them to
+    # be mounted at "/"
+    "puppetlabs.services.ca.certificate-authority-service/certificate-authority-service": {
+      default: {
+        route: ""
+        server: "ca"
+      }
+    }
+    "puppetlabs.services.master.master-service/master-service": ""
+
+    # This controls the mount point for the puppet admin API.
+    "puppetlabs.services.puppet-admin.puppet-admin-service/puppet-admin-service": "/puppet-admin-api"
+}
+~,
+          'require' => 'Package[puppetserver]',
+          'notify'  => 'Service[puppetserver]'
+        }) }
+
+        it { is_expected.to contain_file('/etc/puppetserver/conf.d/webserver.conf').with({
+          'ensure'  => 'file',
+          'owner'   => 'root',
+          'group'   => 'puppet',
+          'mode'    => '0640',
+          'content' => %q~# This file managed by Puppet
+# Any changes will be removed on the next run
+webserver: {
+  base: {
+    client-auth: need
+    ssl-crl-path: /var/lib/puppet/ssl/crl.pem
+    ssl-ca-cert: /var/lib/puppet/ssl/certs/ca.pem
+    ssl-cert: /var/lib/puppet/ssl/certs/foo.example.com.pem
+    ssl-key: /var/lib/puppet/ssl/private_keys/foo.example.com.pem
+    ssl-host: 0.0.0.0
+    ssl-port: 8140
+    default-server: true
+  }
+  ca: {
+    client-auth: want
+    ssl-crl-path: /var/lib/puppet/ssl/crl.pem
+    ssl-ca-cert: /var/lib/puppet/ssl/certs/ca.pem
+    ssl-cert: /var/lib/puppet/ssl/certs/foo.example.com.pem
+    ssl-key: /var/lib/puppet/ssl/private_keys/foo.example.com.pem
+    ssl-host: 0.0.0.0
+    ssl-port: 8141
+  }
+}
+~,
+          'require' => 'Package[puppetserver]',
+          'notify'  => 'Service[puppetserver]'
+        }) }
+
+        it { is_expected.to contain_pupmod__conf('master_environmentpath').with({
+          'section' => ['master'],
+          'setting' => 'environmentpath',
+          'value'   => '/etc/puppet/environments',
+          'notify'  => 'Service[puppetserver]'
+        }) }
+
+        it { is_expected.to contain_pupmod__conf('master_daemonize').with({
+          'section' => ['master'],
+          'setting' => 'daemonize',
+          'value'   => 'true',
+          'notify'  => 'Service[puppetserver]'
+        }) }
+
+        it { is_expected.to contain_pupmod__conf('master_masterport').with({
+          'section' => ['master'],
+          'setting' => 'masterport',
+          'value'   => '8140',
+          'notify'  => 'Service[puppetserver]'
+        }) }
+
+        it { is_expected.to contain_pupmod__conf('master_ca').with({
+          'section' => ['master'],
+          'setting' => 'ca',
+          'value'   => 'true',
+          'notify'  => 'Service[puppetserver]'
+        }) }
+
+        it { is_expected.to contain_pupmod__conf('master_ca_port').with({
+          'section' => ['master'],
+          'setting' => 'ca_port',
+          'value'   => '8141',
+          'notify'  => 'Service[puppetserver]'
+        }) }
+
+        it { is_expected.to contain_pupmod__conf('ca_ttl').with({
+          'section' => ['master'],
+          'setting' => 'ca_ttl',
+          'value'   => '10y',
+          'notify'  => 'Service[puppetserver]'
+        }) }
+
+        # fips_enabled fact take precedence over hieradata use_fips
+        it { is_expected.to contain_pupmod__conf('keylength').with({
+          'section' => ['master'],
+          'setting' => 'keylength',
+          'value'   => '4096',
+          'notify'  => 'Service[puppetserver]'
+        }) }
+
+        it { is_expected.to contain_pupmod__conf('freeze_main').with({
+          'setting' => 'freeze_main',
+          'value'   => 'false',
+          'notify'  => 'Service[puppetserver]'
+        }) }
+
+        it { is_expected.to contain_class('iptables') }
+        it { 
+          pending "Requires fix to simplib's nets2cidr, which does not convert IPv4 addresses to CIDR"
+          is_expected.to contain_iptables__add_tcp_stateful_listen('allow_puppet').with({
+            'order'       => '11',
+            'client_nets' => ['127.0.0.1/32','::1/128'],
+            'dports'      => '8140'
+        }) }
+
+        it { 
+          pending "Requires fix to simplib's nets2cidr, which does not convert IPv4 addresses to CIDR"
+          is_expected.to contain_iptables__add_tcp_stateful_listen('allow_puppetca').with({
+            'order'       => '11',
+            'client_nets' => ['127.0.0.1/32','::1/128'],
+            'dports'      => '8141'
+        }) }
+      end 
+
+      describe "with non-default parameters" do
+        context 'with enable_ca => false' do
+          let(:params) {{:enable_ca => false}}
+          it { is_expected.to contain_file('/etc/puppetserver/bootstrap.cfg').with({
+            'ensure'  => 'file',
+            'owner'   => 'root',
+            'group'   => 'puppet',
+            'mode'    => '0640',
+            'content' => %q{# This file managed by Puppet
+# Any changes will be removed on the next run
+puppetlabs.services.request-handler.request-handler-service/request-handler-service
+puppetlabs.services.jruby.jruby-puppet-service/jruby-puppet-pooled-service
+puppetlabs.services.puppet-profiler.puppet-profiler-service/puppet-profiler-service
+puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
+puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-service
+puppetlabs.services.config.puppet-server-config-service/puppet-server-config-service
+puppetlabs.services.master.master-service/master-service
+puppetlabs.services.version.version-check-service/version-check-service
+puppetlabs.services.puppet-admin.puppet-admin-service/puppet-admin-service
+
+puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service
+},
+            'require' => 'Package[puppetserver]',
+            'notify'  => 'Service[puppetserver]'
+          }) }
+        end
+
+        context 'with log_to_syslog => false and log_to_file => true' do
+          let(:params) {{:log_to_syslog => false, :log_to_file => true}}
+          it { is_expected.to contain_file('/etc/puppetserver/logback.xml').with({
+            'ensure'  => 'file',
+            'owner'   => 'root',
+            'group'   => 'puppet',
+            'mode'    => '0640',
+            'content' => %q~<!--
+  This file managed by Puppet.
+  Any changes will be erased at the next run.
+-->
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d %-5p [%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="SYSLOG" class="ch.qos.logback.classic.net.SyslogAppender">
+      <syslogHost>localhost</syslogHost>
+      <facility>LOCAL6</facility>
+      <suffixPattern>%logger[%thread]: %msg</suffixPattern>
+      <throwableExcluded>true</throwableExcluded>
+    </appender>
+
+    <appender name="F1" class="ch.qos.logback.core.FileAppender">
+        <file>/var/log/puppetserver/puppetserver.log</file>
+        <append>true</append>
+        <encoder>
+            <pattern>%d %-5p [%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.eclipse.jetty" level="WARN"/>
+
+    <root level="WARN">
+        <appender-ref ref="F1"/>
+    </root>
+</configuration>
+~,
+          'require' => 'Package[puppetserver]',
+          'notify'  => 'Service[puppetserver]'
+        }) }
+        end
+
+        context 'with multiple entries in ca_status_whitelist' do
+          let(:params) {{:ca_status_whitelist => ['1.2.3.4', '5.6.7.8']}}
+          it { is_expected.to contain_file('/etc/puppetserver/conf.d/ca.conf').with({
+            'ensure'  => 'file',
+            'owner'   => 'root',
+            'group'   => 'puppet',
+            'mode'    => '0640',
+            'content' => %q~# This file managed by Puppet
+# Any changes will be removed on the next run
+
+# CA-related settings
+certificate-authority: {
+
+    # settings for the certificate_status HTTP endpoint
+    certificate-status: {
+
+        # this setting contains a list of client certnames who are whitelisted to
+        # have access to the certificate_status endpoint.  Any requests made to
+        # this endpoint that do not present a valid client cert mentioned in
+        # this list will be denied access.
+        client-whitelist: [1.2.3.4,5.6.7.8]
+    }
+}
+~,
+            'require' => 'Package[puppetserver]',
+            'notify'  => 'Service[puppetserver]'
+          }) }
+        end
+
+        context 'with non-empty ruby_load_path' do
+          let(:params) {{:ruby_load_path => '/some/ruby/path'}}
+          it { is_expected.to contain_file('/etc/puppetserver/conf.d/os-settings.conf').with({
+            'ensure'  => 'file',
+            'owner'   => 'root',
+            'group'   => 'puppet',
+            'mode'    => '0640',
+            'content' => %q~# This file managed by Puppet
+# Any changes will be removed on the next run
+os-settings: {
+    ruby-load-path: [/some/ruby/path]
+}
+~,
+            'require' => 'Package[puppetserver]',
+            'notify'  => 'Service[puppetserver]'
+          }) }
+        end
+
+        context 'with non-empty gem_home, empty ssl_protocols, non-empty ssl_cipher_suites, and multiple admin_api_whitelist entries' do
+          let(:params) {{
+            :gem_home => '/some/gem/path',
+            :ssl_protocols => [],
+            :ssl_cipher_suites => ['suite1', 'suite2'],
+            :admin_api_whitelist => ['foo.example.com', 'bar.example.com']
+          }}
+          it { is_expected.to contain_file('/etc/puppetserver/conf.d/puppetserver.conf').with({
+            'ensure'  => 'file',
+            'owner'   => 'root',
+            'group'   => 'puppet',
+            'mode'    => '0640',
+            'content' => %q~# This file managed by Puppet
+# Any changes will be removed on the next run
+
+# configuration for the JRuby interpreters
+jruby-puppet: {
+    # This setting determines where JRuby will look for gems.  It is also
+    # used by the `puppetserver gem` command line tool.
+    gem-home: /some/gem/path
+
+    # (optional) path to puppet conf dir; if not specified, will use the puppet default
+    master-conf-dir: /etc/puppet
+
+    # (optional) path to puppet var dir; if not specified, will use the puppet default
+    master-var-dir: /var/lib/puppet
+
+    # (optional) maximum number of JRuby instances to allow; defaults to <num-cpus>+2
+    max-active-instances: 3
+}
+
+# settings related to HTTP client requests made by Puppet Server
+http-client: {
+    # A list of acceptable cipher suites for making HTTP requests
+    cipher-suites: [suite1,suite2]
+}
+
+# settings related to profiling the puppet Ruby code
+profiler: {
+    # enable or disable profiling for the Ruby code; defaults to 'false'.
+    enabled: false
+}
+
+# Settings related to the puppet-admin HTTP API
+puppet-admin: {
+    client-whitelist: [foo.example.com,bar.example.com]
+}
+~,
+            'require' => 'Package[puppetserver]',
+            'notify'  => 'Service[puppetserver]'
+          }) }
+        end
+
+        context 'when admin_api_mountpoints does not begin with / and enable_ca => false' do
+          let(:params) {{
+            :admin_api_mountpoint => 'admin_mount_point',
+            :enable_ca => false
+          }}
+          it { is_expected.to contain_file('/etc/puppetserver/conf.d/web-routes.conf').with({
+            'ensure'  => 'file',
+            'owner'   => 'root',
+            'group'   => 'puppet',
+            'mode'    => '0640',
+            'content' => %q~# This file managed by Puppet
+# Any changes will be removed on the next run
+web-router-service: {
+    # These two should not be modified because the Puppet 3.x agent expects them to
+    # be mounted at "/"
+    "puppetlabs.services.ca.certificate-authority-service/certificate-authority-service": ""
+    "puppetlabs.services.master.master-service/master-service": ""
+
+    # This controls the mount point for the puppet admin API.
+    "puppetlabs.services.puppet-admin.puppet-admin-service/puppet-admin-service": "/admin_mount_point"
+}
+~,
+            'require' => 'Package[puppetserver]',
+            'notify'  => 'Service[puppetserver]'
+          }) }
+        end
+
+        context 'when enable_ca => true and ca_port == masterport' do
+          let(:params) {{
+            :enable_ca => false,
+            :ca_port => '12345',
+            :masterport => '12345'
+       
+          }}
+          it { is_expected.to contain_file('/etc/puppetserver/conf.d/web-routes.conf').with({
+            'ensure'  => 'file',
+            'owner'   => 'root',
+            'group'   => 'puppet',
+            'mode'    => '0640',
+            'content' => %q~# This file managed by Puppet
+# Any changes will be removed on the next run
+web-router-service: {
+    # These two should not be modified because the Puppet 3.x agent expects them to
+    # be mounted at "/"
+    "puppetlabs.services.ca.certificate-authority-service/certificate-authority-service": ""
+    "puppetlabs.services.master.master-service/master-service": ""
+
+    # This controls the mount point for the puppet admin API.
+    "puppetlabs.services.puppet-admin.puppet-admin-service/puppet-admin-service": "/puppet-admin-api"
+}
+~,
+            'require' => 'Package[puppetserver]',
+            'notify'  => 'Service[puppetserver]'
+          }) }
+        end
+
+        context 'when enable_master =>false' do
+          let(:params) {{ :enable_master => false }}
+       
+          it { is_expected.to contain_file('/etc/puppetserver/conf.d/webserver.conf').with({
+            'ensure'  => 'file',
+            'owner'   => 'root',
+            'group'   => 'puppet',
+            'mode'    => '0640',
+            'content' => %q~# This file managed by Puppet
+# Any changes will be removed on the next run
+webserver: {
+  ca: {
+    client-auth: want
+    ssl-crl-path: /var/lib/puppet/ssl/crl.pem
+    ssl-ca-cert: /var/lib/puppet/ssl/certs/ca.pem
+    ssl-cert: /var/lib/puppet/ssl/certs/foo.example.com.pem
+    ssl-key: /var/lib/puppet/ssl/private_keys/foo.example.com.pem
+    ssl-host: 0.0.0.0
+    ssl-port: 8141
+    default-server: true
+  }
+}
+~,
+            'require' => 'Package[puppetserver]',
+            'notify'  => 'Service[puppetserver]'
+          }) }
+        end
+
+        context 'when enable_ca =>false' do
+          let(:params) {{ :enable_ca => false }}
+          it { is_expected.to contain_file('/etc/puppetserver/conf.d/webserver.conf').with({
+            'ensure'  => 'file',
+            'owner'   => 'root',
+            'group'   => 'puppet',
+            'mode'    => '0640',
+            'content' => %q~# This file managed by Puppet
+# Any changes will be removed on the next run
+webserver: {
+  base: {
+    client-auth: need
+    ssl-crl-path: /var/lib/puppet/ssl/crl.pem
+    ssl-ca-cert: /var/lib/puppet/ssl/certs/ca.pem
+    ssl-cert: /var/lib/puppet/ssl/certs/foo.example.com.pem
+    ssl-key: /var/lib/puppet/ssl/private_keys/foo.example.com.pem
+    ssl-host: 0.0.0.0
+    ssl-port: 8140
+    default-server: true
+  }
+}
+~,
+            'require' => 'Package[puppetserver]',
+            'notify'  => 'Service[puppetserver]'
+          }) }
+        end
+
+        context 'when ca_port == masterport' do
+          let(:params) {{ :ca_port => 12345, :masterport => 12345 }}
+          it { is_expected.to contain_file('/etc/puppetserver/conf.d/webserver.conf').with({
+            'ensure'  => 'file',
+            'owner'   => 'root',
+            'group'   => 'puppet',
+            'mode'    => '0640',
+            'content' => %q~# This file managed by Puppet
+# Any changes will be removed on the next run
+webserver: {
+  base: {
+    client-auth: want
+    ssl-crl-path: /var/lib/puppet/ssl/crl.pem
+    ssl-ca-cert: /var/lib/puppet/ssl/certs/ca.pem
+    ssl-cert: /var/lib/puppet/ssl/certs/foo.example.com.pem
+    ssl-key: /var/lib/puppet/ssl/private_keys/foo.example.com.pem
+    ssl-host: 0.0.0.0
+    ssl-port: 12345
+    default-server: true
+  }
+}
+~,
+            'require' => 'Package[puppetserver]',
+            'notify'  => 'Service[puppetserver]'
+          }) }
+        end
+      end
     end
   end
 end

--- a/templates/commands/crl_download.erb
+++ b/templates/commands/crl_download.erb
@@ -1,5 +1,4 @@
 <%
-  t_ssldir = @vardir + @ssldir.gsub('$vardir','')
   t_ca_server = @ca_server.gsub('$server',@puppet_server)
 -%>
-/usr/bin/curl -sS --cert <%= t_ssldir %>/certs/<%= @certname %>.pem --key <%= t_ssldir %>/private_keys/<%= @certname %>.pem -k -o <%= t_ssldir %>/crl.pem -H "Accept: s" https://<%= t_ca_server %>:<%= @ca_port %>/production/certificate_revocation_list/ca
+/usr/bin/curl -sS --cert <%= @ssldir %>/certs/<%= @certname %>.pem --key <%= @ssldir %>/private_keys/<%= @certname %>.pem -k -o <%= @ssldir %>/crl.pem -H "Accept: s" https://<%= t_ca_server %>:<%= @ca_port %>/production/certificate_revocation_list/ca

--- a/templates/etc/puppetserver/conf.d/puppetserver.conf.erb
+++ b/templates/etc/puppetserver/conf.d/puppetserver.conf.erb
@@ -6,7 +6,7 @@ jruby-puppet: {
     # This setting determines where JRuby will look for gems.  It is also
     # used by the `puppetserver gem` command line tool.
 <% if @gem_home.empty? -%>
-    gem-home: <%= scope.lookupvar('::pupmod::vardir') + 'jruby-gems' %>
+    gem-home: <%= scope.lookupvar('::pupmod::vardir') + '/jruby-gems' %>
 <% else -%>
     gem-home: <%= @gem_home %>
 <% end -%>

--- a/templates/etc/puppetserver/conf.d/webserver.conf.erb
+++ b/templates/etc/puppetserver/conf.d/webserver.conf.erb
@@ -1,6 +1,5 @@
 <%
-  vardir = scope.lookupvar('::pupmod::vardir')
-  ssldir = scope.lookupvar('::pupmod::ssldir').gsub('$vardir',vardir)
+  _ssldir = scope.lookupvar('::pupmod::ssldir')
 -%>
 # This file managed by Puppet
 # Any changes will be removed on the next run
@@ -12,10 +11,10 @@ webserver: {
 <%   else -%>
     client-auth: need
 <%   end -%>
-    ssl-crl-path: <%= ssldir %>/crl.pem
-    ssl-ca-cert: <%= ssldir %>/certs/ca.pem
-    ssl-cert: <%= ssldir %>/certs/<%= @fqdn %>.pem
-    ssl-key: <%= ssldir %>/private_keys/<%= @fqdn %>.pem
+    ssl-crl-path: <%= _ssldir %>/crl.pem
+    ssl-ca-cert: <%= _ssldir %>/certs/ca.pem
+    ssl-cert: <%= _ssldir %>/certs/<%= @fqdn %>.pem
+    ssl-key: <%= _ssldir %>/private_keys/<%= @fqdn %>.pem
     ssl-host: <%= @bind_address %>
     ssl-port: <%= @masterport %>
     default-server: true
@@ -24,15 +23,15 @@ webserver: {
 <% if @enable_ca && (@ca_port != @masterport) -%>
   ca: {
     client-auth: want
-    ssl-crl-path: <%= ssldir %>/crl.pem
-    ssl-ca-cert: <%= ssldir %>/certs/ca.pem
-    ssl-cert: <%= ssldir %>/certs/<%= @fqdn %>.pem
-    ssl-key: <%= ssldir %>/private_keys/<%= @fqdn %>.pem
+    ssl-crl-path: <%= _ssldir %>/crl.pem
+    ssl-ca-cert: <%= _ssldir %>/certs/ca.pem
+    ssl-cert: <%= _ssldir %>/certs/<%= @fqdn %>.pem
+    ssl-key: <%= _ssldir %>/private_keys/<%= @fqdn %>.pem
     ssl-host: <%= @ca_bind_address %>
     ssl-port: <%= @ca_port %>
-<% if !@enable_master -%>
+<%   if !@enable_master -%>
     default-server: true
-<% end -%>
+<%   end -%>
   }
 <% end -%>
 }


### PR DESCRIPTION
Fixed the following:
- Expanded pupmod::ssldir so that the puppet-specific, '$vardir'
  string no longer appears in the puppet_master audit rule.
- Fixed a bug that resulted in a malformed directory setting for the
  gem-home parameter in puppetserver.conf.

Also improved test coverage.

SIMP-1675 #close
