### PR TITLE
(SIMP-2043) Ignore environmentpath if empty

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue Nov 17 2016 Nick Miller <nick.miller@onyxpoint.com> - 6.0.10-0
+- Fixed validatation of environmentpath
+
 * Mon Nov 07 2016 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.9-0
 - Expanded pupmod::ssldir so that the puppet-specific, '$vardir'
   string no longer appears in the puppet_master audit rule.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -240,7 +240,7 @@ class pupmod (
   validate_bool($daemonize)
   validate_string($digest_algorithm)
   validate_bool($enable_puppet_master)
-  validate_re($environmentpath,'^(\$(?!/)|/).+')
+  if !empty($environmentpath) { validate_re($environmentpath,'^(\$(?!/)|/).+') }
   validate_bool($listen)
   validate_re($localconfig,'^(\$(?!/)|/).+')
   validate_re($logdir,'^(\$(?!/)|/).+')

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pupmod",
-  "version": "6.0.9",
+  "version": "6.0.10",
   "author": "SIMP",
   "summary": "A puppet module to manage puppet",
   "license": "Apache-2.0",
@@ -10,7 +10,9 @@
   "tags": [
     "simp",
     "ci",
-    "pupmod"
+    "pupmod",
+    "puppetserver",
+    "puppet"
   ],
   "dependencies": [
     {


### PR DESCRIPTION
On agents, the puppet environmentpath is empty, but it is still required
to be nonempty by a validate function. This update skips the validation
if the environmentpath is empty.

SIMP-2043 #close