### PR TITLE
(SIMP-2418) Increase code coverage up to 100%

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,3 +1,4 @@
+#
 # A class for managing Puppet configurations.
 #
 # This is mainly a stub class for hooking other classes along the way
@@ -113,6 +114,9 @@
 # @param haveged
 #   If true, include haveged to assist with entropy generation.
 #
+# @param fips
+#   If true, enable fips mode
+#
 # @param vardir
 #   The directory where puppet will store all of its 'variable' data.
 #
@@ -144,8 +148,8 @@ class pupmod (
   Simplib::Syslog::Facility $syslogfacility       = 'local6',
   Boolean                   $use_srv_records      = false,
   Stdlib::AbsolutePath      $vardir               = $::pupmod::params::puppet_config['vardir'],
-  Boolean                   $haveged              = simplib::lookup('simp_options::haveged', { 'default_value' => false }),
-  Boolean                   $fips                 = simplib::lookup('simp_options::fips', { 'default_value' => false }),
+  Boolean                   $haveged              = simplib::lookup('simp_options::haveged', { 'default_value'                     => false }),
+  Boolean                   $fips                 = simplib::lookup('simp_options::fips', { 'default_value'                        => false }),
 ) inherits pupmod::params {
 
   validate_re($classfile,'^(\$(?!/)|/).+')
@@ -322,12 +326,7 @@ class pupmod (
     include 'auditd'
 
     auditd::add_rules { 'puppet_master':
-      content => "
-        -a always,exit -F dir=${confdir} -F uid!=puppet -p wa -k Puppet_Config
-        -a always,exit -F dir=${logdir} -F uid!=puppet -p wa -k Puppet_Log
-        -a always,exit -F dir=${rundir} -F uid!=puppet -p wa -k Puppet_Run
-        -a always,exit -F dir=${ssldir} -F uid!=puppet -p wa -k Puppet_SSL
-      "
+      content => template('pupmod/puppet-auditd-rules.erb'),
     }
   }
 

--- a/spec/classes/agent/cron_spec.rb
+++ b/spec/classes/agent/cron_spec.rb
@@ -1,3 +1,4 @@
+#
 require 'spec_helper'
 
 describe 'pupmod::agent::cron' do
@@ -14,7 +15,12 @@ describe 'pupmod::agent::cron' do
         it { is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(
           /service puppet stop > \/dev\/null 2>&1/
         )}
-
+        it { is_expected.to contain_cron('puppetd').with(
+            {
+              "ensure" => "absent",
+            }
+          )
+        }
         it { is_expected.to contain_cron('puppetagent').with({
             'minute'    => [27,57],
             'hour'      => '*',

--- a/spec/classes/data/auditd.txt
+++ b/spec/classes/data/auditd.txt
@@ -1,0 +1,4 @@
+-a always,exit -F dir=/etc/puppetlabs/puppet -F uid!=puppet -p wa -k Puppet_Config
+-a always,exit -F dir=/var/log/puppetlabs/puppet -F uid!=puppet -p wa -k Puppet_Log
+-a always,exit -F dir=/var/run/puppetlabs -F uid!=puppet -p wa -k Puppet_Run
+-a always,exit -F dir=/etc/puppetlabs/puppet/ssl -F uid!=puppet -p wa -k Puppet_SSL

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,3 +1,4 @@
+#
 require 'spec_helper'
 
 describe 'pupmod' do
@@ -6,223 +7,263 @@ describe 'pupmod' do
       @extras = { :puppet_settings => {
         'master' => {
           'rest_authconfig' => '/etc/puppetlabs/puppet/authconf.conf'
-      }}}
+        }}}
     end
-    context "on #{os}" do
-      let(:facts){ @extras.merge(os_facts) }
+      context "on #{os}" do
+        let(:facts){ @extras.merge(os_facts) }
 
-      describe "with default parameters" do
-        it { is_expected.to create_class('pupmod') }
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.not_to contain_class('haveged') }
-        it { is_expected.to contain_package('puppet-agent').with_ensure('latest') }
-        it { is_expected.to contain_file('/etc/puppetlabs/puppet').with({
-          'ensure' => 'directory',
-          'owner'  => 'root',
-          'group'  => 'root',
-          'mode'   => '0640'
-        }) }
-
-        it { is_expected.to contain_file('/etc/puppetlabs/puppet/puppet.conf').with({
-          'ensure' => 'file',
-          'owner'  => 'root',
-          'group'  => 'root',
-          'mode'   => '0640',
-          'audit'  => 'content'
-        }) }
-
-        it { is_expected.to contain_cron('puppet_crl_pull').with_command(
-         %q{/usr/bin/curl -sS --cert /etc/puppetlabs/puppet/ssl/certs/foo.example.com.pem --key /etc/puppetlabs/puppet/ssl/private_keys/foo.example.com.pem -k -o /etc/puppetlabs/puppet/ssl/crl.pem -H "Accept: s" https://1.2.3.4:8141/puppet-ca/v1/certificate_revocation_list/ca
-}) }
-
-        it { is_expected.to contain_cron('puppet_crl_pull').with_user('root') }
-        it { is_expected.to contain_class('pupmod::agent::cron') }
-        it { is_expected.to contain_pupmod__conf('agent_daemonize').with({
-          'section' => 'agent',
-          'setting' => 'daemonize',
-          'value' => 'false'
-        }) }
-
-        it { is_expected.to contain_pupmod__conf('server').with({
-          'setting' => 'server',
-          'value' => '1.2.3.4'
-        }) }
-
-        it { is_expected.to contain_pupmod__conf('ca_server').with({
-          'setting' => 'ca_server',
-          'value' => '$server'
-        }) }
-
-        it { is_expected.to contain_pupmod__conf('masterport').with({
-          'setting' => 'masterport',
-          'value' => 8140
-        }) }
-
-        it { is_expected.to contain_pupmod__conf('report').with({
-          'section' => 'agent',
-          'setting' => 'report',
-          'value' => false
-        }) }
-
-        it { is_expected.to contain_pupmod__conf('ca_port').with({
-          'setting' => 'ca_port',
-          'value' => 8141
-        }) }
-
-        it { is_expected.to contain_pupmod__conf('splay').with({
-          'setting' => 'splay',
-          'value' => false
-        }) }
-        it { is_expected.not_to contain_pupmod__conf('splaylimit') }
-       it { is_expected.to contain_pupmod__conf('syslogfacility').with({
-          'setting' => 'syslogfacility',
-          'value' => 'local6'
-        }) }
-
-        it { is_expected.to contain_pupmod__conf('srv_domain').with({
-          'setting' => 'srv_domain',
-          'value' => 'example.com'
-        }) }
-
-        it { is_expected.to contain_pupmod__conf('certname').with({
-          'setting' => 'certname',
-          'value' => 'foo.example.com'
-        }) }
-
-        it { is_expected.to contain_pupmod__conf('classfile').with({
-          'setting' => 'classfile',
-          'value' => '$vardir/classes.txt'
-        }) }
-
-        it { is_expected.to contain_pupmod__conf('confdir').with({
-          'setting' => 'confdir',
-          'value' => '/etc/puppetlabs/puppet'
-        }) }
-
-        it { is_expected.to contain_pupmod__conf('logdir').with({
-          'setting' => 'logdir',
-          'value' => '/var/log/puppetlabs/puppet'
-        }) }
-
-        it { is_expected.to contain_pupmod__conf('rundir').with({
-          'setting' => 'rundir',
-          'value' => '/var/run/puppetlabs'
-        }) }
-
-        it { is_expected.to contain_pupmod__conf('runinterval').with({
-          'setting' => 'runinterval',
-          'value' => 1800
-        }) }
-
-        it { is_expected.to contain_pupmod__conf('ssldir').with({
-          'setting' => 'ssldir',
-          'value' => '/etc/puppetlabs/puppet/ssl'
-        }) }
-
-        it { is_expected.to contain_pupmod__conf('stringify_facts').with({
-          'setting' => 'stringify_facts',
-          'value' => false
-        }) }
-
-        it { is_expected.to contain_pupmod__conf('digest_algorithm').with({
-          'setting' => 'digest_algorithm',
-          'value' => 'sha256'
-        }) }
-
-        it { is_expected.to contain_class('auditd') }
-        it { is_expected.to contain_auditd__add_rules('puppet_master').with_content( %q{
-        -a always,exit -F dir=/etc/puppetlabs/puppet -F uid!=puppet -p wa -k Puppet_Config
-        -a always,exit -F dir=/var/log/puppetlabs/puppet -F uid!=puppet -p wa -k Puppet_Log
-        -a always,exit -F dir=/var/run/puppetlabs -F uid!=puppet -p wa -k Puppet_Run
-        -a always,exit -F dir=/etc/puppetlabs/puppet/ssl -F uid!=puppet -p wa -k Puppet_SSL
-      }) }
-
-        it { is_expected.to contain_file('/etc/sysconfig/puppet').with({
-          'ensure'  => 'file',
-          'owner'   => 'root',
-          'group'   => 'root',
-          'mode'    => '0644',
-          'content' => "PUPPET_EXTRA_OPTS='--daemonize'\n"
-        }) }
-
-        it 'operatingsystem < 7' do
-          if os_facts[:operatingsystemmajrelease].to_i < 7
-            is_expected.to contain_selboolean('puppet_manage_all_files')
-          else
-            is_expected.to contain_selboolean('puppetagent_manage_all_files')
-          end
-        end
-
-        context 'with_selinux_disabled' do
-          let(:facts) {
-            _facts = @extras.merge(os_facts)
-            _facts[:selinux_current_mode] = 'disabled'
-            _facts[:selinux] = false
-
-            _facts
-          }
-
-          if os_facts[:operatingsystemmajrelease].to_i < 7 then
-            it { is_expected.not_to contain_selboolean('puppet_manage_all_files') }
-          else
-            it { is_expected.not_to contain_selboolean('puppetagent_manage_all_files') }
-          end
-        end
-      end
-
-      describe "with non-default parameters" do
-        context 'with haveged => true' do
-          let(:params) {{ :haveged => true }}
-          it { is_expected.to contain_class('haveged') }
-        end
-
-        context 'with enable_puppet_master => false' do
-          let(:params) {{ :enable_puppet_master => true, }}
-          it { is_expected.to create_class('pupmod::master') }
+        describe "with default parameters" do
+          it { is_expected.to create_class('pupmod') }
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.not_to contain_class('haveged') }
+          it { is_expected.to contain_package('puppet-agent').with_ensure('latest') }
           it { is_expected.to contain_file('/etc/puppetlabs/puppet').with({
             'ensure' => 'directory',
             'owner'  => 'root',
-            'group'  => 'puppet',
+            'group'  => 'root',
             'mode'   => '0640'
           }) }
 
           it { is_expected.to contain_file('/etc/puppetlabs/puppet/puppet.conf').with({
             'ensure' => 'file',
             'owner'  => 'root',
-            'group'  => 'puppet',
+            'group'  => 'root',
             'mode'   => '0640',
             'audit'  => 'content'
           }) }
-        end
 
-        context 'with daemonize enabled' do
-          let(:params) {{:daemonize => true}}
-          it { is_expected.to contain_cron('puppetagent').with_ensure('absent') }
-          it { is_expected.to contain_service('puppet').with({
-            'ensure'     => 'running',
-            'enable'     => true,
-            'hasrestart' => true,
-            'hasstatus'  => false,
-            'status'     => '/usr/bin/test `/bin/ps --no-headers -fC puppetd,"puppet agent" | /usr/bin/wc -l` -ge 1 -a ! `/bin/ps --no-headers -fC puppetd,"puppet agent" | /bin/grep -c "no-daemonize"` -ge 1',
-            'subscribe'  => 'File[/etc/puppetlabs/puppet/puppet.conf]'
+          it { is_expected.to contain_cron('puppet_crl_pull').with_command(
+            "/usr/bin/curl -sS --cert /etc/puppetlabs/puppet/ssl/certs/foo.example.com.pem --key /etc/puppetlabs/puppet/ssl/private_keys/foo.example.com.pem -k -o /etc/puppetlabs/puppet/ssl/crl.pem -H \"Accept: s\" https://1.2.3.4:8141/puppet-ca/v1/certificate_revocation_list/ca\n") }
+
+          it { is_expected.to contain_cron('puppet_crl_pull').with_user('root') }
+          it { is_expected.to contain_class('pupmod::agent::cron') }
+          it { is_expected.to contain_pupmod__conf('agent_daemonize').with({
+            'section' => 'agent',
+            'setting' => 'daemonize',
+            'value' => 'false'
           }) }
-        end
 
-        context 'with non-empty splaylimit' do
-          let(:params) {{:splaylimit => 5}}
-          it { is_expected.to contain_pupmod__conf('splaylimit').with({
-            'setting' => 'splaylimit',
-            'value' => 5
+          it { is_expected.to contain_pupmod__conf('server').with({
+            'setting' => 'server',
+            'value' => '1.2.3.4'
           }) }
+
+          it { is_expected.to contain_pupmod__conf('ca_server').with({
+            'setting' => 'ca_server',
+            'value' => '$server'
+          }) }
+
+          it { is_expected.to contain_pupmod__conf('masterport').with({
+            'setting' => 'masterport',
+            'value' => 8140
+          }) }
+
+          it { is_expected.to contain_pupmod__conf('report').with({
+            'section' => 'agent',
+            'setting' => 'report',
+            'value' => false
+          }) }
+
+          it { is_expected.to contain_pupmod__conf('ca_port').with({
+            'setting' => 'ca_port',
+            'value' => 8141
+          }) }
+
+          it { is_expected.to contain_pupmod__conf('splay').with({
+            'setting' => 'splay',
+            'value' => false
+          }) }
+          it { is_expected.not_to contain_pupmod__conf('splaylimit') }
+          it { is_expected.to contain_pupmod__conf('syslogfacility').with({
+            'setting' => 'syslogfacility',
+            'value' => 'local6'
+          }) }
+
+          it { is_expected.to contain_pupmod__conf('srv_domain').with({
+            'setting' => 'srv_domain',
+            'value' => 'example.com'
+          }) }
+
+          it { is_expected.to contain_pupmod__conf('certname').with({
+            'setting' => 'certname',
+            'value' => 'foo.example.com'
+          }) }
+
+          it { is_expected.to contain_pupmod__conf('vardir').with({
+            'setting' => 'vardir',
+            'value' => '/opt/puppetlabs/puppet/cache',
+          }) }
+
+          it { is_expected.to contain_pupmod__conf('classfile').with({
+            'setting' => 'classfile',
+             'value' => '$vardir/classes.txt'
+          }) }
+
+          it { is_expected.to contain_pupmod__conf('confdir').with({
+            'setting' => 'confdir',
+            'value' => '/etc/puppetlabs/puppet'
+          }) }
+
+          it { is_expected.to contain_pupmod__conf('logdir').with({
+            'setting' => 'logdir',
+            'value' => '/var/log/puppetlabs/puppet'
+          }) }
+
+          it { is_expected.to contain_pupmod__conf('rundir').with({
+            'setting' => 'rundir',
+            'value' => '/var/run/puppetlabs'
+          }) }
+
+          it { is_expected.to contain_pupmod__conf('runinterval').with({
+            'setting' => 'runinterval',
+            'value' => 1800
+          }) }
+
+          it { is_expected.to contain_pupmod__conf('ssldir').with({
+            'setting' => 'ssldir',
+            'value' => '/etc/puppetlabs/puppet/ssl'
+          }) }
+
+          it { is_expected.to contain_pupmod__conf('stringify_facts').with({
+            'setting' => 'stringify_facts',
+            'value' => false
+          }) }
+
+          it { is_expected.to contain_pupmod__conf('digest_algorithm').with({
+            'setting' => 'digest_algorithm',
+            'value' => 'sha256'
+          }) }
+          it { is_expected.to contain_ini_setting("pupmod_agent_daemonize") }
+
+          it { is_expected.to contain_ini_setting("pupmod_server") }
+
+          it { is_expected.to contain_ini_setting("pupmod_ca_server") }
+
+          it { is_expected.to contain_ini_setting("pupmod_masterport") }
+
+          it { is_expected.to contain_ini_setting("pupmod_report") }
+
+          it { is_expected.to contain_ini_setting("pupmod_ca_port") }
+
+          it { is_expected.to contain_ini_setting("pupmod_splay") }
+
+          it { is_expected.to contain_ini_setting("pupmod_syslogfacility") }
+
+          it { is_expected.to contain_ini_setting("pupmod_srv_domain") }
+
+          it { is_expected.to contain_ini_setting("pupmod_certname") }
+
+          it { is_expected.to contain_ini_setting("pupmod_vardir") }
+
+          it { is_expected.to contain_ini_setting("pupmod_classfile") }
+
+          it { is_expected.to contain_ini_setting("pupmod_confdir") }
+
+          it { is_expected.to contain_ini_setting("pupmod_logdir") }
+
+          it { is_expected.to contain_ini_setting("pupmod_rundir") }
+
+          it { is_expected.to contain_ini_setting("pupmod_runinterval") }
+
+          it { is_expected.to contain_ini_setting("pupmod_ssldir") }
+
+          it { is_expected.to contain_ini_setting("pupmod_stringify_facts") }
+
+          it { is_expected.to contain_ini_setting("pupmod_digest_algorithm") }
+
+          it { is_expected.to contain_class('auditd') }
+          audit_content = File.open("#{File.dirname(__FILE__)}/data/auditd.txt", "rb").read;
+
+          it { is_expected.to contain_auditd__add_rules('puppet_master').with_content(audit_content)}
+
+          it { is_expected.to contain_file('/etc/sysconfig/puppet').with({
+            'ensure'  => 'file',
+            'owner'   => 'root',
+            'group'   => 'root',
+            'mode'    => '0644',
+            'content' => "PUPPET_EXTRA_OPTS='--daemonize'\n"
+          }) }
+          it 'operatingsystem < 7' do
+            if os_facts[:operatingsystemmajrelease].to_i < 7
+              is_expected.to contain_selboolean('puppet_manage_all_files')
+            else
+              is_expected.to contain_selboolean('puppetagent_manage_all_files')
+            end
+          end
+
+          context 'with_selinux_disabled' do
+            let(:facts) {
+              _facts = @extras.merge(os_facts)
+              _facts[:selinux_current_mode] = 'disabled'
+              _facts[:selinux] = false
+
+              _facts
+            }
+
+            if os_facts[:operatingsystemmajrelease].to_i < 7 then
+              it { is_expected.not_to contain_selboolean('puppet_manage_all_files') }
+            else
+              it { is_expected.not_to contain_selboolean('puppetagent_manage_all_files') }
+            end
+          end
         end
 
-        context 'with auditd_support => false' do
-          let(:params) {{:auditd_support => false}}
-          it { is_expected.to_not contain_class('auditd') }
-          it { is_expected.to_not contain_auditd__add_rules('puppet_master') }
+        describe "with non-default parameters" do
+          context 'with haveged => true' do
+            let(:params) {{ :haveged => true }}
+            it { is_expected.to contain_class('haveged') }
+          end
+
+          context 'with enable_puppet_master => false' do
+            let(:params) {{ :enable_puppet_master => true, }}
+            it { is_expected.to create_class('pupmod::master') }
+            it { is_expected.to contain_file('/etc/puppetlabs/puppet').with({
+              'ensure' => 'directory',
+              'owner'  => 'root',
+              'group'  => 'puppet',
+              'mode'   => '0640'
+            }) }
+
+            it { is_expected.to contain_file('/etc/puppetlabs/puppet/puppet.conf').with({
+              'ensure' => 'file',
+              'owner'  => 'root',
+              'group'  => 'puppet',
+              'mode'   => '0640',
+              'audit'  => 'content'
+            }) }
+          end
+
+          context 'with daemonize enabled' do
+            let(:params) {{:daemonize => true}}
+            it { is_expected.to contain_cron('puppetagent').with_ensure('absent') }
+            it { is_expected.to contain_service('puppet').with({
+              'ensure'     => 'running',
+              'enable'     => true,
+              'hasrestart' => true,
+              'hasstatus'  => false,
+              'status'     => '/usr/bin/test `/bin/ps --no-headers -fC puppetd,"puppet agent" | /usr/bin/wc -l` -ge 1 -a ! `/bin/ps --no-headers -fC puppetd,"puppet agent" | /bin/grep -c "no-daemonize"` -ge 1',
+              'subscribe'  => 'File[/etc/puppetlabs/puppet/puppet.conf]'
+            }) }
+          end
+
+          context 'with non-empty splaylimit' do
+            let(:params) {{:splaylimit => 5}}
+            it { is_expected.to contain_pupmod__conf('splaylimit').with({
+              'setting' => 'splaylimit',
+              'value' => 5
+            }) }
+
+            it { is_expected.to contain_ini_setting("pupmod_splaylimit") }
+
+          end
+
+          context 'with auditd_support => false' do
+            let(:params) {{:auditd_support => false}}
+            it { is_expected.to_not contain_class('auditd') }
+            it { is_expected.to_not contain_auditd__add_rules('puppet_master') }
+          end
         end
+
       end
-
     end
-  end
 end

--- a/spec/classes/master/base_spec.rb
+++ b/spec/classes/master/base_spec.rb
@@ -1,3 +1,4 @@
+#
 require 'spec_helper'
 
 describe 'pupmod::master::base' do
@@ -14,8 +15,108 @@ describe 'pupmod::master::base' do
 
       context 'with default parameters' do
         it { is_expected.to create_class('pupmod::master::base') }
-        it { is_expected.to contain_user('puppet') }
-        it { is_expected.to contain_group('puppet') }
+        it { is_expected.to contain_simpcat_build('autosign').with(
+            {
+              "quiet" => true,
+              "order" => ['*.autosign'],
+              "target" => "/etc/puppetlabs/puppet/autosign.conf",
+            }
+          )
+        }
+        it { is_expected.to contain_exec('puppetserver_reload').with(
+            {
+              "command" => "/usr/local/sbin/puppetserver_reload",
+              "refreshonly" => true,
+            }
+          )
+        }
+        it { is_expected.to contain_file('/etc/puppetlabs/puppet/ssl/ca/ca_crl.pem').with(
+            {
+              "audit" => "content",
+            }
+          )
+        }
+        it { is_expected.to contain_file('/etc/puppetlabs/puppetserver/conf.d/autosign.conf').with(
+            {
+              "owner" => "root",
+              "group" => "puppet",
+              "mode" => "0644",
+            }
+          )
+        }
+        it { is_expected.to contain_file('/etc/puppetlabs/code/environments').with(
+            {
+              "ensure" => "directory",
+              "owner" => "root",
+              "group" => "puppet",
+              "mode" => "u=rwx,g=rwx,o-rwx",
+              "recurse" => true,
+              "recurselimit" => 1,
+            }
+          )
+        }
+        it { is_expected.to contain_file('/usr/local/sbin/puppetserver_clear_environment_cache').with(
+            {
+              "ensure" => "file",
+              "owner" => "root",
+              "group"  => "root",
+              "mode" => "0700",
+            }
+          )
+        }
+        puppetserver_clear_environment_cache = File.open("#{File.dirname(__FILE__)}/data/puppetserver_clear_environment_cache.txt", "rb").read;
+        it { is_expected.to contain_file('/usr/local/sbin/puppetserver_clear_environment_cache').with_content(puppetserver_clear_environment_cache) }
+
+        it { is_expected.to contain_file('/usr/local/sbin/puppetserver_reload').with(
+            {
+              "ensure" => "file",
+              "owner" => "root",
+              "group"  => "root",
+              "mode" => "0700",
+            }
+          )
+        }
+        puppetserver_reload = File.open("#{File.dirname(__FILE__)}/data/puppetserver_reload.txt", "rb").read;
+        it { is_expected.to contain_file('/usr/local/sbin/puppetserver_reload').with_content(puppetserver_reload) }
+
+        it { is_expected.to contain_group('puppet').with(
+            {
+              "ensure" => "present",
+              "allowdupe" => false,
+              "gid" => "52",
+              "tag" => "firstrun",
+            }
+          )
+        }
+        it { is_expected.to contain_package('puppetserver').with(
+            {
+              "ensure" => "latest",
+            }
+          )
+        }
+        it { is_expected.to contain_service('puppetserver').with(
+            {
+              "ensure" => "running",
+              "enable" => true,
+              "hasrestart" => true,
+              "hasstatus" => true,
+            }
+          )
+        }
+        it { is_expected.to contain_user('puppet').with(
+            {
+              "ensure" => "present",
+              "allowdupe" => false,
+              "comment" => "Puppet User",
+              "uid" => "52",
+              "gid" => "puppet",
+              "home" => "/opt/puppetlabs/server/data/puppetserver",
+              "membership" => "inclusive",
+              "shell" => "/sbin/nologin",
+              "tag" => "firstrun",
+            }
+          )
+        }
       end
     end
   end

--- a/spec/classes/master/data/puppetserver.txt
+++ b/spec/classes/master/data/puppetserver.txt
@@ -1,0 +1,14 @@
+# Location of your Java binary (version 7 or higher)
+JAVA_BIN="/usr/bin/java"
+
+# Modify this if you'd like to change the memory allocation, enable JMX, etc
+JAVA_ARGS="-Xms245m -Xmx245m -Djava.io.tmpdir=/opt/puppetlabs/puppet/cache/pserver_tmp"
+
+# These normally shouldn't need to be edited if using OS packages
+USER="puppet"
+GROUP="puppet"
+INSTALL_DIR="/opt/puppetlabs/server/apps/puppetserver"
+CONFIG="/etc/puppetlabs/puppetserver/conf.d"
+BOOTSTRAP_CONFIG="/etc/puppetlabs/puppetserver/services.d/,/opt/puppetlabs/server/apps/puppetserver/config/services.d/"
+SERVICE_STOP_RETRIES=60
+START_TIMEOUT="120"

--- a/spec/classes/master/data/puppetserver_clear_environment_cache.txt
+++ b/spec/classes/master/data/puppetserver_clear_environment_cache.txt
@@ -1,0 +1,11 @@
+# A simple script for clearing the environment cache on the local server
+
+PATH=/opt/puppetlabs/bin:$PATH
+
+cert=`puppet config print hostcert`
+key=`puppet config print hostprivkey`
+cacert=`puppet config print localcacert`
+
+resp=`curl -o /dev/null -L -w "%{http_code}" -s -i --cert ${cert} --key ${key} --cacert ${cacert} -X DELETE https://foo.example.com:8140/puppet-admin-api/v1/environment-cache`
+
+test "$resp" -eq '204'

--- a/spec/classes/master/data/puppetserver_reload.txt
+++ b/spec/classes/master/data/puppetserver_reload.txt
@@ -1,0 +1,11 @@
+# A simple script for reloading the Puppet Server JRuby instances
+
+PATH=/opt/puppetlabs/bin:$PATH
+
+cert=`puppet config print hostcert`
+key=`puppet config print hostprivkey`
+cacert=`puppet config print localcacert`
+
+resp=`curl -o /dev/null -L -w "%{http_code}" -s -i --cert ${cert} --key ${key} --cacert ${cacert} -X DELETE https://foo.example.com:8140/puppet-admin-api/v1/jruby-pool`
+
+test "$resp" -eq '204'

--- a/spec/classes/master/sysconfig_spec.rb
+++ b/spec/classes/master/sysconfig_spec.rb
@@ -1,0 +1,40 @@
+#
+require 'spec_helper'
+
+describe 'pupmod::master::sysconfig' do
+  on_supported_os.each do |os, os_facts|
+    before :all do
+      @extras = { :puppet_settings => {
+        'master' => {
+          'rest_authconfig' => '/etc/puppetlabs/puppet/authconf.conf'
+      }}}
+    end
+    context "on #{os}" do
+
+      let(:facts){ @extras.merge(os_facts) }
+
+      context 'with default parameters' do
+        it { is_expected.to create_class('pupmod::master::sysconfig') }
+        it { is_expected.to contain_file('/opt/puppetlabs/puppet/cache/pserver_tmp').with(
+            {
+              'owner' => 'puppet',
+              'group' => 'puppet',
+              'ensure' => 'directory',
+              'mode' => '0750'
+            }
+          )
+        }
+        puppetserver_content = File.open("#{File.dirname(__FILE__)}/data/puppetserver.txt", "rb").read;
+        it { is_expected.to contain_file('/etc/sysconfig/puppetserver').with(
+            {
+              'owner' => 'root',
+              'group' => 'root',
+              'mode' => '0640',
+            }
+          )
+        }
+        it { is_expected.to contain_file('/etc/sysconfig/puppetserver').with_content(puppetserver_content) }
+      end
+    end
+  end
+end

--- a/spec/classes/master_spec.rb
+++ b/spec/classes/master_spec.rb
@@ -315,6 +315,21 @@ webserver: {
           'value'   => false,
           'notify'  => 'Service[puppetserver]'
         }) }
+        it { is_expected.to contain_ini_setting("pupmod_master_environmentpath") }
+
+        it { is_expected.to contain_ini_setting("pupmod_master_daemonize") }
+
+        it { is_expected.to contain_ini_setting("pupmod_master_masterport") }
+
+        it { is_expected.to contain_ini_setting("pupmod_master_ca") }
+
+        it { is_expected.to contain_ini_setting("pupmod_master_ca_port") }
+
+        it { is_expected.to contain_ini_setting("pupmod_ca_ttl") }
+
+        it { is_expected.to contain_ini_setting("pupmod_keylength") }
+
+        it { is_expected.to contain_ini_setting("pupmod_freeze_main") }
 
         it { is_expected.not_to contain_class('iptables') }
         it { is_expected.not_to contain_iptables__listen__tcp_stateful('allow_puppet') }
@@ -681,3 +696,4 @@ webserver: {
     end
   end
 end
+

--- a/spec/classes/params_spec.rb
+++ b/spec/classes/params_spec.rb
@@ -1,0 +1,5 @@
+#
+require 'spec_helper'
+describe "pupmod::params" do
+  it { is_expected.to contain_class("pupmod::params") }
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -143,6 +143,9 @@ RSpec.configure do |c|
     FileUtils.rm_rf(@spec_global_env_temp)
     @spec_global_env_temp = nil
   end
+  c.after(:suite) do
+    RSpec::Puppet::Coverage.report!(100)
+  end
 end
 
 Dir.glob("#{RSpec.configuration.module_path}/*").each do |dir|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -143,9 +143,6 @@ RSpec.configure do |c|
     FileUtils.rm_rf(@spec_global_env_temp)
     @spec_global_env_temp = nil
   end
-  c.after(:suite) do
-    RSpec::Puppet::Coverage.report!(100)
-  end
 end
 
 Dir.glob("#{RSpec.configuration.module_path}/*").each do |dir|

--- a/templates/puppet-auditd-rules.erb
+++ b/templates/puppet-auditd-rules.erb
@@ -1,0 +1,4 @@
+-a always,exit -F dir=<%= @confdir %> -F uid!=puppet -p wa -k Puppet_Config
+-a always,exit -F dir=<%= @logdir %> -F uid!=puppet -p wa -k Puppet_Log
+-a always,exit -F dir=<%= @rundir %> -F uid!=puppet -p wa -k Puppet_Run
+-a always,exit -F dir=<%= @ssldir %> -F uid!=puppet -p wa -k Puppet_SSL


### PR DESCRIPTION
* Increase spec test coverage to 100% of resources.
* Add some missing documentation
* clean up how some files are laid down (template instead of inline
content).
* clean up how spec test data is being passed in. It was previously
  sensitive to indentation causing spurious spec failures.
* Flesh out some existing tests to hit more parameters.

SIMP-2418 #close