### PR TITLE
(SIMP-2504) Use PE node classification to configure pupmod

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -32,5 +32,8 @@ fixtures:
     simpcat: https://github.com/simp/pupmod-simp-simpcat
     simplib: https://github.com/simp/pupmod-simp-simplib
     stdlib: https://github.com/simp/puppetlabs-stdlib
+    puppet_enterprise:
+      repo: https://github.com/simp/pupmod-mock-puppet_enterprise
+      ref: 0.1.0
   symlinks:
     pupmod: "#{source_dir}"

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ dist
 /pkg
 /spec/fixtures
 /spec/rp_env
-!/spec/hieradata/default.yaml
+!/spec/hieradata
 !/spec/fixtures/site.pp
 /.rspec_system
 /.vagrant

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,0 +1,69 @@
+---
+pupmod::pe_classlist:
+  pupmod:
+   users:
+      - root
+  pupmod::master:
+    users:
+      - puppet
+  puppet_enterprise::profile::puppetdb:
+    users:
+      - pe-puppetdb
+      - pe-postgres
+    services:
+      - pe-puppetdb
+      - pe-postgresql
+    firewall_rules:
+      - proto: tcp
+        port: 8081
+      - proto: tcp
+        port: 5432
+  puppet_enterprise::profile::console:
+    users:
+      - pe-webserver
+      - pe-console-services
+    services:
+      - pe-console-services
+      - pe-nginx
+    firewall_rules:
+      - proto: tcp
+        port: 443
+      - proto: tcp
+        port: 4431
+      - proto: tcp
+        port: 4433
+  puppet_enterprise::profile::amq::broker:
+    users:
+      - pe-activemq
+    services:
+      - pe-activemq
+    firewall_rules:
+      - proto: tcp
+        port: 45826
+      - proto: tcp
+        port: 61613
+      - proto: tcp
+        port: 61616
+  puppet_enterprise::profile::orchestrator:
+    users:
+      - pe-orchestration-services
+    services:
+      - pe-orchestration-services
+    firewall_rules:
+      - proto: tcp
+        port: 8142
+      - proto: tcp
+        port: 8143
+  puppet_enterprise::profile::master:
+    users:
+      - pe-puppet
+    services:
+      - pe-puppetserver
+    firewall_rules:
+      - proto: tcp
+        port: 8140
+      - proto: tcp
+        port: 8170
+lookup::options:
+  pupmod::pe_classlist:
+    merge: deep

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,6 @@
+---
+version: 4
+datadir: data
+hierarchy:
+  - name: "common"
+    backend: yaml

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -20,14 +20,14 @@
 define pupmod::conf (
   String $setting,
   Scalar $value,
+  String $confdir,
   String $section = 'main'
 ) {
-  include '::pupmod'
 
   $l_name = "${module_name}_${name}"
 
   ini_setting { $l_name:
-    path    => "${::pupmod::confdir}/puppet.conf",
+    path    => "${confdir}/puppet.conf",
     section => $section,
     setting => $setting,
     # This needs to be a string to take effect!

--- a/manifests/master/base.pp
+++ b/manifests/master/base.pp
@@ -60,13 +60,6 @@ class pupmod::master::base {
     content => template('pupmod/usr/local/sbin/puppetserver_reload.erb')
   }
 
-  group { 'puppet':
-    ensure    => 'present',
-    allowdupe => false,
-    gid       => '52',
-    tag       => 'firstrun',
-    require   => Package[$::pupmod::master::service]
-  }
 
   package { $::pupmod::master::service:
     ensure => 'latest',

--- a/manifests/pass_two.pp
+++ b/manifests/pass_two.pp
@@ -1,0 +1,171 @@
+define pupmod::pass_two (
+  $namerar = $name,
+  $server_distribution = 'PC1',
+  $confdir = '/etc/puppetlabs/puppet',
+  $firewall = undef,
+  $pe_classlist = lookup('pupmod::pe_classlist'),
+  $pupmod_server = '1.2.3.4',
+  $pupmod_ca_server = '$server',
+  $pupmod_ca_port = 8141,
+  $pupmod_report = false,
+  $pupmod_masterport = 8140,
+) {
+  if (defined(Class['puppet_enterprise'])) {
+    $_server_distribution = 'PE'
+  } else {
+    $_server_distribution = $server_distribution
+  }
+
+
+  # These are agent specific variables, that only apply on PC1 systems:
+
+  if ($_server_distribution == 'PC1') {
+    pupmod::conf { 'server':
+      confdir => $confdir,
+      setting => 'server',
+      value   => $pupmod_server,
+    }
+
+    pupmod::conf { 'ca_server':
+      confdir => $confdir,
+      setting => 'ca_server',
+      value   => $pupmod_ca_server,
+    }
+
+    pupmod::conf { 'masterport':
+      confdir => $confdir,
+      setting => 'masterport',
+      value   => $pupmod_masterport,
+    }
+
+    pupmod::conf { 'ca_port':
+      confdir => $confdir,
+      setting => 'ca_port',
+      value   => $pupmod_ca_port,
+
+    }
+    pupmod::conf { 'report':
+      section => 'agent',
+      confdir => $confdir,
+      setting => 'report',
+      value   => $pupmod_report,
+    }
+  }
+
+  $_conf_group = 'puppet'
+
+  # These two maps allow the user and service specifications to occur purely in data
+  # and can be included /only/ if the node is classified into the applicable groups.
+  # this is necessary as a LEI install of PE has several seperate, independent
+  # roles that can be applied, not just master|agent.
+  #
+  # This also prevents us from passing the burden onto the user to classify
+  # their nodes with two classes, one for SIMP, and one for PE.
+  # 
+  # For safety that means that releases of SIMP are only supported on specified PE 
+  # releases. We need to have a matrix of supported versions.
+  if ($_server_distribution == 'PE') {
+    $available = $pe_classlist.map |$class, $data| {
+      if (defined(Class[$class])) {
+        $data['users']
+      }
+    }
+
+    $notify_resources = $pe_classlist.map |$class, $data| {
+      if (defined(Class[$class])) {
+        if ($data['services'] != undef) {
+          # lint:ignore:variable_scope
+          $data['services'].map |$service| { Service[$service] }
+          # lint:endignore
+          }
+      }
+    }
+    $group_notify = unique(flatten(delete_undef_values($notify_resources)))
+    $group_members = unique(flatten(delete_undef_values($available)))
+  } else {
+    $group_notify = undef
+    $group_members = undef
+  }
+
+  # All of those functions are required to make this 'safe' and 
+  # indempotent.
+  group { $_conf_group:
+    ensure    => 'present',
+    allowdupe => false,
+    gid       => '52',
+    tag       => 'firstrun',
+    notify    => $group_notify,
+    members   => $group_members,
+  }
+
+  # We cannot assume that every user is
+  # going to read the SIMP docs before they attempt to classify a
+  # class, and we also cannot assume they know what would happen
+  # if pupmod::master and puppet_enterprise::profile::master
+  # are applied at the same time.
+  #
+  # Hell, I don't even know what would happen. But it would be bad
+  # Very, very bad.
+  if (defined(Class['puppet_enterprise::profile::master'])) {
+    if (defined(Class['pupmod::master'])) {
+      fail('pupmod::master is NOT supported on PE masters. Please remove the pupmod::master classification from hiera or the puppet console before proceeding')
+    } else {
+      class { 'pupmod::master::sysconfig':
+        server_distribution => 'PE',
+        service             => 'pe-puppetserver',
+        user                => 'pe-puppet',
+      }
+    }
+  }
+
+  if ($_server_distribution == 'PC1') {
+    $shared_mode = '0640'
+  } elsif ($_server_distribution == 'PE') {
+    $shared_mode = undef
+  }
+  file { $confdir:
+    ensure => 'directory',
+    owner  => 'root',
+    group  => $_conf_group,
+    mode   => $shared_mode
+  }
+
+  file { "${confdir}/puppet.conf":
+    ensure => 'file',
+    owner  => 'root',
+    group  => $_conf_group,
+    mode   => $shared_mode,
+    audit  => content
+  }
+
+  # Generate firewall rules on a per-class basis.
+  # Basically, only when a node is classified with a role will we poke
+  # a hole in the firewall for it
+  # 
+  # Only create tcp rules since that's all puppet uses. But support it
+  # in the data model anyway
+  if ($firewall) {
+    if ($_server_distribution == 'PE') {
+      # lint:ignore:variable_scope
+      $pe_classlist.each |String $class, Hash $data| {
+        if (defined(Class[$class])) {
+          $rules = $data['firewall_rules']
+          if ($rules != undef) {
+            $rules.each |Hash $data| {
+              case ($data['proto']) {
+                'tcp' : {
+                  iptables::listen::tcp_stateful { "${class} - ${data['proto']} - ${data['port']}":
+                    dports => $data['port'],
+                  }
+                }
+                default: {
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    # lint:endignore
+    }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -75,5 +75,6 @@
         "7"
       ]
     }
-  ]
+  ],
+  "data_provider": "hiera"
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,6 +1,5 @@
-#
 require 'spec_helper'
-
+audit_content = File.open("#{File.dirname(__FILE__)}/data/auditd.txt", "rb").read;
 describe 'pupmod' do
   on_supported_os.each do |os, os_facts|
     before :all do
@@ -9,261 +8,206 @@ describe 'pupmod' do
           'rest_authconfig' => '/etc/puppetlabs/puppet/authconf.conf'
         }}}
     end
-      context "on #{os}" do
-        let(:facts){ @extras.merge(os_facts) }
+    context "on #{os}" do
+      let(:facts){ @extras.merge(os_facts) }
+      [
+        'PC1',
+        'PE'
+      ].each do |distribution|
+        context "with server_distribution = #{distribution}" do
+          let(:params) {{ :server_distribution => distribution, :puppet_server => '1.2.3.4' }}
+          describe "with default parameters" do
+            it { is_expected.to create_class('pupmod') }
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.not_to contain_class('haveged') }
+            it { is_expected.to contain_package('puppet-agent').with_ensure('latest') }
+            it { is_expected.to contain_cron('puppet_crl_pull').with_command(
+              "/usr/bin/curl -sS --cert /etc/puppetlabs/puppet/ssl/certs/foo.example.com.pem --key /etc/puppetlabs/puppet/ssl/private_keys/foo.example.com.pem -k -o /etc/puppetlabs/puppet/ssl/crl.pem -H \"Accept: s\" https://1.2.3.4:8141/puppet-ca/v1/certificate_revocation_list/ca\n") }
 
-        describe "with default parameters" do
-          it { is_expected.to create_class('pupmod') }
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.not_to contain_class('haveged') }
-          it { is_expected.to contain_package('puppet-agent').with_ensure('latest') }
-          it { is_expected.to contain_file('/etc/puppetlabs/puppet').with({
-            'ensure' => 'directory',
-            'owner'  => 'root',
-            'group'  => 'root',
-            'mode'   => '0640'
-          }) }
-
-          it { is_expected.to contain_file('/etc/puppetlabs/puppet/puppet.conf').with({
-            'ensure' => 'file',
-            'owner'  => 'root',
-            'group'  => 'root',
-            'mode'   => '0640',
-            'audit'  => 'content'
-          }) }
-
-          it { is_expected.to contain_cron('puppet_crl_pull').with_command(
-            "/usr/bin/curl -sS --cert /etc/puppetlabs/puppet/ssl/certs/foo.example.com.pem --key /etc/puppetlabs/puppet/ssl/private_keys/foo.example.com.pem -k -o /etc/puppetlabs/puppet/ssl/crl.pem -H \"Accept: s\" https://1.2.3.4:8141/puppet-ca/v1/certificate_revocation_list/ca\n") }
-
-          it { is_expected.to contain_cron('puppet_crl_pull').with_user('root') }
-          it { is_expected.to contain_class('pupmod::agent::cron') }
-          it { is_expected.to contain_pupmod__conf('agent_daemonize').with({
-            'section' => 'agent',
-            'setting' => 'daemonize',
-            'value' => 'false'
-          }) }
-
-          it { is_expected.to contain_pupmod__conf('server').with({
-            'setting' => 'server',
-            'value' => '1.2.3.4'
-          }) }
-
-          it { is_expected.to contain_pupmod__conf('ca_server').with({
-            'setting' => 'ca_server',
-            'value' => '$server'
-          }) }
-
-          it { is_expected.to contain_pupmod__conf('masterport').with({
-            'setting' => 'masterport',
-            'value' => 8140
-          }) }
-
-          it { is_expected.to contain_pupmod__conf('report').with({
-            'section' => 'agent',
-            'setting' => 'report',
-            'value' => false
-          }) }
-
-          it { is_expected.to contain_pupmod__conf('ca_port').with({
-            'setting' => 'ca_port',
-            'value' => 8141
-          }) }
-
-          it { is_expected.to contain_pupmod__conf('splay').with({
-            'setting' => 'splay',
-            'value' => false
-          }) }
-          it { is_expected.not_to contain_pupmod__conf('splaylimit') }
-          it { is_expected.to contain_pupmod__conf('syslogfacility').with({
-            'setting' => 'syslogfacility',
-            'value' => 'local6'
-          }) }
-
-          it { is_expected.to contain_pupmod__conf('srv_domain').with({
-            'setting' => 'srv_domain',
-            'value' => 'example.com'
-          }) }
-
-          it { is_expected.to contain_pupmod__conf('certname').with({
-            'setting' => 'certname',
-            'value' => 'foo.example.com'
-          }) }
-
-          it { is_expected.to contain_pupmod__conf('vardir').with({
-            'setting' => 'vardir',
-            'value' => '/opt/puppetlabs/puppet/cache',
-          }) }
-
-          it { is_expected.to contain_pupmod__conf('classfile').with({
-            'setting' => 'classfile',
-             'value' => '$vardir/classes.txt'
-          }) }
-
-          it { is_expected.to contain_pupmod__conf('confdir').with({
-            'setting' => 'confdir',
-            'value' => '/etc/puppetlabs/puppet'
-          }) }
-
-          it { is_expected.to contain_pupmod__conf('logdir').with({
-            'setting' => 'logdir',
-            'value' => '/var/log/puppetlabs/puppet'
-          }) }
-
-          it { is_expected.to contain_pupmod__conf('rundir').with({
-            'setting' => 'rundir',
-            'value' => '/var/run/puppetlabs'
-          }) }
-
-          it { is_expected.to contain_pupmod__conf('runinterval').with({
-            'setting' => 'runinterval',
-            'value' => 1800
-          }) }
-
-          it { is_expected.to contain_pupmod__conf('ssldir').with({
-            'setting' => 'ssldir',
-            'value' => '/etc/puppetlabs/puppet/ssl'
-          }) }
-
-          it { is_expected.to contain_pupmod__conf('stringify_facts').with({
-            'setting' => 'stringify_facts',
-            'value' => false
-          }) }
-
-          it { is_expected.to contain_pupmod__conf('digest_algorithm').with({
-            'setting' => 'digest_algorithm',
-            'value' => 'sha256'
-          }) }
-          it { is_expected.to contain_ini_setting("pupmod_agent_daemonize") }
-
-          it { is_expected.to contain_ini_setting("pupmod_server") }
-
-          it { is_expected.to contain_ini_setting("pupmod_ca_server") }
-
-          it { is_expected.to contain_ini_setting("pupmod_masterport") }
-
-          it { is_expected.to contain_ini_setting("pupmod_report") }
-
-          it { is_expected.to contain_ini_setting("pupmod_ca_port") }
-
-          it { is_expected.to contain_ini_setting("pupmod_splay") }
-
-          it { is_expected.to contain_ini_setting("pupmod_syslogfacility") }
-
-          it { is_expected.to contain_ini_setting("pupmod_srv_domain") }
-
-          it { is_expected.to contain_ini_setting("pupmod_certname") }
-
-          it { is_expected.to contain_ini_setting("pupmod_vardir") }
-
-          it { is_expected.to contain_ini_setting("pupmod_classfile") }
-
-          it { is_expected.to contain_ini_setting("pupmod_confdir") }
-
-          it { is_expected.to contain_ini_setting("pupmod_logdir") }
-
-          it { is_expected.to contain_ini_setting("pupmod_rundir") }
-
-          it { is_expected.to contain_ini_setting("pupmod_runinterval") }
-
-          it { is_expected.to contain_ini_setting("pupmod_ssldir") }
-
-          it { is_expected.to contain_ini_setting("pupmod_stringify_facts") }
-
-          it { is_expected.to contain_ini_setting("pupmod_digest_algorithm") }
-
-          it { is_expected.to contain_class('auditd') }
-          audit_content = File.open("#{File.dirname(__FILE__)}/data/auditd.txt", "rb").read;
-
-          it { is_expected.to contain_auditd__rule('puppet_master').with_content(audit_content)}
-
-          it { is_expected.to contain_file('/etc/sysconfig/puppet').with({
-            'ensure'  => 'file',
-            'owner'   => 'root',
-            'group'   => 'root',
-            'mode'    => '0644',
-            'content' => "PUPPET_EXTRA_OPTS='--daemonize'\n"
-          }) }
-          it 'operatingsystem < 7' do
-            if os_facts[:operatingsystemmajrelease].to_i < 7
-              is_expected.to contain_selboolean('puppet_manage_all_files')
-            else
-              is_expected.to contain_selboolean('puppetagent_manage_all_files')
-            end
-          end
-
-          context 'with_selinux_disabled' do
-            let(:facts) {
-              _facts = @extras.merge(os_facts)
-              _facts[:selinux_current_mode] = 'disabled'
-              _facts[:selinux] = false
-
-              _facts
-            }
-
-            if os_facts[:operatingsystemmajrelease].to_i < 7 then
-              it { is_expected.not_to contain_selboolean('puppet_manage_all_files') }
-            else
-              it { is_expected.not_to contain_selboolean('puppetagent_manage_all_files') }
-            end
-          end
-        end
-
-        describe "with non-default parameters" do
-          context 'with haveged => true' do
-            let(:params) {{ :haveged => true }}
-            it { is_expected.to contain_class('haveged') }
-          end
-
-          context 'with enable_puppet_master => false' do
-            let(:params) {{ :enable_puppet_master => true, }}
-            it { is_expected.to create_class('pupmod::master') }
-            it { is_expected.to contain_file('/etc/puppetlabs/puppet').with({
-              'ensure' => 'directory',
-              'owner'  => 'root',
-              'group'  => 'puppet',
-              'mode'   => '0640'
+            it { is_expected.to contain_cron('puppet_crl_pull').with_user('root') }
+            it { is_expected.to contain_class('pupmod::agent::cron') }
+            it { is_expected.to contain_pupmod__conf('agent_daemonize').with({
+              'section' => 'agent',
+              'setting' => 'daemonize',
+              'value' => 'false'
             }) }
 
-            it { is_expected.to contain_file('/etc/puppetlabs/puppet/puppet.conf').with({
-              'ensure' => 'file',
-              'owner'  => 'root',
-              'group'  => 'puppet',
-              'mode'   => '0640',
-              'audit'  => 'content'
+            it { is_expected.to contain_pupmod__conf('splay').with({
+              'setting' => 'splay',
+              'value' => false
             }) }
-          end
-
-          context 'with daemonize enabled' do
-            let(:params) {{:daemonize => true}}
-            it { is_expected.to contain_cron('puppetagent').with_ensure('absent') }
-            it { is_expected.to contain_service('puppet').with({
-              'ensure'     => 'running',
-              'enable'     => true,
-              'hasrestart' => true,
-              'hasstatus'  => false,
-              'status'     => '/usr/bin/test `/bin/ps --no-headers -fC puppetd,"puppet agent" | /usr/bin/wc -l` -ge 1 -a ! `/bin/ps --no-headers -fC puppetd,"puppet agent" | /bin/grep -c "no-daemonize"` -ge 1',
-              'subscribe'  => 'File[/etc/puppetlabs/puppet/puppet.conf]'
-            }) }
-          end
-
-          context 'with non-empty splaylimit' do
-            let(:params) {{:splaylimit => 5}}
-            it { is_expected.to contain_pupmod__conf('splaylimit').with({
-              'setting' => 'splaylimit',
-              'value' => 5
+            it { is_expected.not_to contain_pupmod__conf('splaylimit') }
+            it { is_expected.to contain_pupmod__conf('syslogfacility').with({
+              'setting' => 'syslogfacility',
+              'value' => 'local6'
             }) }
 
-            it { is_expected.to contain_ini_setting("pupmod_splaylimit") }
+            it { is_expected.to contain_pupmod__conf('srv_domain').with({
+              'setting' => 'srv_domain',
+              'value' => 'example.com'
+            }) }
 
-          end
+            it { is_expected.to contain_pupmod__conf('certname').with({
+              'setting' => 'certname',
+              'value' => 'foo.example.com'
+            }) }
 
-          context 'with auditd_support => false' do
-            let(:params) {{:auditd_support => false}}
+            it { is_expected.to contain_pupmod__conf('vardir').with({
+              'setting' => 'vardir',
+              'value' => '/opt/puppetlabs/puppet/cache',
+            }) }
+
+            it { is_expected.to contain_pupmod__conf('classfile').with({
+              'setting' => 'classfile',
+              'value' => '$vardir/classes.txt'
+            }) }
+
+            it { is_expected.to contain_pupmod__conf('confdir').with({
+              'setting' => 'confdir',
+              'value' => '/etc/puppetlabs/puppet'
+            }) }
+
+            it { is_expected.to contain_pupmod__conf('logdir').with({
+              'setting' => 'logdir',
+              'value' => '/var/log/puppetlabs/puppet'
+            }) }
+
+            it { is_expected.to contain_pupmod__conf('rundir').with({
+              'setting' => 'rundir',
+              'value' => '/var/run/puppetlabs'
+            }) }
+
+            it { is_expected.to contain_pupmod__conf('runinterval').with({
+              'setting' => 'runinterval',
+              'value' => 1800
+            }) }
+
+            it { is_expected.to contain_pupmod__conf('ssldir').with({
+              'setting' => 'ssldir',
+              'value' => '/etc/puppetlabs/puppet/ssl'
+            }) }
+
+            it { is_expected.to contain_pupmod__conf('stringify_facts').with({
+              'setting' => 'stringify_facts',
+              'value' => false
+            }) }
+
+            it { is_expected.to contain_pupmod__conf('digest_algorithm').with({
+              'setting' => 'digest_algorithm',
+              'value' => 'sha256'
+            }) }
+            it { is_expected.to contain_ini_setting("pupmod_agent_daemonize") }
+
+            it { is_expected.to contain_ini_setting("pupmod_splay") }
+
+            it { is_expected.to contain_ini_setting("pupmod_syslogfacility") }
+
+            it { is_expected.to contain_ini_setting("pupmod_srv_domain") }
+
+            it { is_expected.to contain_ini_setting("pupmod_certname") }
+
+            it { is_expected.to contain_ini_setting("pupmod_vardir") }
+
+            it { is_expected.to contain_ini_setting("pupmod_classfile") }
+
+            it { is_expected.to contain_ini_setting("pupmod_confdir") }
+
+            it { is_expected.to contain_ini_setting("pupmod_logdir") }
+
+          it { is_expected.to_not contain_class('auditd') }
+          it { is_expected.to_not contain_auditd__rule('puppet_master').with_content(audit_content)}
+            it { is_expected.to contain_ini_setting("pupmod_rundir") }
+
+            it { is_expected.to contain_ini_setting("pupmod_runinterval") }
+
+            it { is_expected.to contain_ini_setting("pupmod_ssldir") }
+
+            it { is_expected.to contain_ini_setting("pupmod_stringify_facts") }
+
+            it { is_expected.to contain_ini_setting("pupmod_digest_algorithm") }
+
             it { is_expected.to_not contain_class('auditd') }
-            it { is_expected.to_not contain_auditd__rule('puppet_master') }
+            it { is_expected.to_not contain_auditd__add_rules('puppet_master').with_content(audit_content)}
+
+            it { is_expected.to contain_file('/etc/sysconfig/puppet').with({
+              'ensure'  => 'file',
+              'owner'   => 'root',
+              'group'   => 'root',
+              'mode'    => '0644',
+              'content' => "PUPPET_EXTRA_OPTS='--daemonize'\n"
+            }) }
+            it 'operatingsystem < 7' do
+              if os_facts[:operatingsystemmajrelease].to_i < 7
+                is_expected.to contain_selboolean('puppet_manage_all_files')
+              else
+                is_expected.to contain_selboolean('puppetagent_manage_all_files')
+              end
+            end
+            context 'with_selinux_disabled' do
+              let(:facts) {
+                _facts = @extras.merge(os_facts)
+                _facts[:selinux_current_mode] = 'disabled'
+                _facts[:selinux] = false
+
+                _facts
+              }
+
+              if os_facts[:operatingsystemmajrelease].to_i < 7 then
+                it { is_expected.not_to contain_selboolean('puppet_manage_all_files') }
+              else
+                it { is_expected.not_to contain_selboolean('puppetagent_manage_all_files') }
+              end
+            end
+          end
+
+          describe "with non-default parameters" do
+            context 'with haveged => true' do
+              let(:params) {{ :haveged => true }}
+              it { is_expected.to contain_class('haveged') }
+            end
+
+            context 'with enable_puppet_master => false' do
+              let(:params) {{ :enable_puppet_master => true, }}
+              it { is_expected.to create_class('pupmod::master') }
+            end
+
+            context 'with daemonize enabled' do
+              let(:params) {{:daemonize => true}}
+              it { is_expected.to contain_cron('puppetagent').with_ensure('absent') }
+              it { is_expected.to contain_service('puppet').with({
+                'ensure'     => 'running',
+                'enable'     => true,
+                'hasrestart' => true,
+                'hasstatus'  => false,
+                'status'     => '/usr/bin/test `/bin/ps --no-headers -fC puppetd,"puppet agent" | /usr/bin/wc -l` -ge 1 -a ! `/bin/ps --no-headers -fC puppetd,"puppet agent" | /bin/grep -c "no-daemonize"` -ge 1',
+                'subscribe'  => 'File[/etc/puppetlabs/puppet/puppet.conf]'
+              }) }
+            end
+
+            context 'with non-empty splaylimit' do
+              let(:params) {{:splaylimit => 5}}
+              it { is_expected.to contain_pupmod__conf('splaylimit').with({
+                'setting' => 'splaylimit',
+                'value' => 5
+              }) }
+
+              it { is_expected.to contain_ini_setting("pupmod_splaylimit") }
+
+            end
+
+            context 'with auditd_support => false' do
+              let(:params) {{:auditd_support => false}}
+              it { is_expected.to_not contain_class('auditd') }
+              it { is_expected.to_not contain_auditd__rule('puppet_master').with_content(audit_content)}
+            end
+            context 'with auditd_support => true' do
+              let(:params) {{:auditd_support => true}}
+              it { is_expected.to contain_class('auditd') }
+              it { is_expected.to contain_auditd__rule('puppet_master').with_content(audit_content)}
+            end
           end
         end
-
       end
     end
+  end
 end

--- a/spec/classes/master/sysconfig_spec.rb
+++ b/spec/classes/master/sysconfig_spec.rb
@@ -14,6 +14,16 @@ describe 'pupmod::master::sysconfig' do
       let(:facts){ @extras.merge(os_facts) }
 
       context 'with default parameters' do
+          puppetserver_content = File.open("#{File.dirname(__FILE__)}/data/puppetserver.txt", "rb").read;
+          it { is_expected.to contain_file('/etc/sysconfig/puppetserver').with(
+            {
+              'owner' => 'root',
+              'group' => 'puppet',
+              'mode' => '0640',
+            }
+          )
+          }
+          it { is_expected.to contain_file('/etc/sysconfig/puppetserver').with_content(puppetserver_content) }
         it { is_expected.to create_class('pupmod::master::sysconfig') }
         it { is_expected.to contain_file('/opt/puppetlabs/puppet/cache/pserver_tmp').with(
             {
@@ -24,16 +34,6 @@ describe 'pupmod::master::sysconfig' do
             }
           )
         }
-        puppetserver_content = File.open("#{File.dirname(__FILE__)}/data/puppetserver.txt", "rb").read;
-        it { is_expected.to contain_file('/etc/sysconfig/puppetserver').with(
-            {
-              'owner' => 'root',
-              'group' => 'puppet',
-              'mode' => '0640',
-            }
-          )
-        }
-        it { is_expected.to contain_file('/etc/sysconfig/puppetserver').with_content(puppetserver_content) }
       end
     end
   end

--- a/spec/defines/data/moduledata.yaml
+++ b/spec/defines/data/moduledata.yaml
@@ -1,0 +1,1 @@
+../../../data/common.yaml

--- a/spec/defines/pass_two_spec.rb
+++ b/spec/defines/pass_two_spec.rb
@@ -1,0 +1,191 @@
+require 'spec_helper'
+require 'yaml'
+data = YAML.load_file("#{File.dirname(__FILE__)}/data/moduledata.yaml")
+describe 'pupmod::pass_two' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+      [
+        'PC1',
+        'PE'
+      ].each do |distribution|
+        context "with server_distribution = #{distribution}" do
+          [
+            false,
+            true
+          ].each do |pe_included|
+            context "with puppet_enterprise in the catalog is #{pe_included}" do
+              if (pe_included == true)
+                let(:pre_condition) { 'include ::puppet_enterprise' }
+              end
+              if (pe_included == true or distribution == 'PE')
+                $pe_mode = true
+              else
+                $pe_mode = false
+              end
+              let(:title) { "main" }
+              let(:params) {
+                {
+                  :server_distribution => distribution
+                }
+              }
+              {
+                'server' => {
+                  'value' => '1.2.3.4'
+                },
+                'ca_server' => {
+                  'value' => '$server'
+                },
+                'masterport' => {
+                  'value' => 8140
+                },
+                'report' => {
+                  'value' => false,
+                  'section' => 'agent'
+                },
+                'ca_port' => {
+                  'value' => 8141
+                }
+              }.each do |key, value|
+                if ($pe_mode == true)
+                  it {
+                    is_expected.to_not contain_pupmod__conf(key)
+                  }
+                  it { is_expected.to_not contain_ini_setting("pupmod_#{key}") }
+                else
+                  it {
+                    is_expected.to contain_pupmod__conf(key).with(
+                      {
+                        'setting' => key
+                      }.merge(value)
+                    )
+                  }
+                  it { is_expected.to contain_ini_setting("pupmod_#{key}") }
+                end
+
+              end
+              if ($pe_mode == false)
+                mode = '0640'
+              else
+                mode = nil
+              end
+              it { is_expected.to contain_file('/etc/puppetlabs/puppet').with({
+                'ensure' => 'directory',
+                'owner'  => 'root',
+                'group'  => 'puppet',
+                'mode'   => mode,
+              }) }
+              it { is_expected.to contain_file('/etc/puppetlabs/puppet/puppet.conf').with({
+                'ensure' => 'file',
+                'owner'  => 'root',
+                'group'  => 'puppet',
+                'mode'   => mode,
+                'audit'  => 'content',
+              }) }
+              it { is_expected.to contain_group('puppet').with({
+                'ensure' => 'present',
+                'allowdupe'  => false,
+                'gid'  => '52',
+                'tag'   => 'firstrun',
+              }) }
+
+              if ($pe_mode == true)
+                classlist = data['pupmod::pe_classlist'];
+                classlist.each do |key, value|
+                  unless (key == 'pupmod' or key == 'pupmod::master')
+                    context "when #{key} is included in the catalog" do
+                      let(:pre_condition) {
+                        if (key == 'puppet_enterprise::profile::master')
+                          ret = "
+                            include puppet_enterprise
+                            class { 'pupmod':
+                              mock => true
+                            }
+                            include #{key}
+                          "
+                        else
+                          ret = "
+                            include puppet_enterprise
+                            include #{key}
+                          "
+                        end
+                        ret
+                      }
+
+                      users = value['users']
+                      unless (users == nil)
+                        users.each do |user|
+                          it "should contain Group[puppet] with user #{user} in the members array" do
+                            members = catalogue.resource('group', 'puppet').send(:parameters)[:members]
+                            expect(members.find { |x| x =~ Regexp.new("#{user}")}).to be_truthy
+                          end
+                        end
+                      end
+
+                      services = value['services']
+                      unless (services == nil)
+                        services.each do |service|
+                          it "should contain Group[puppet] that notifies Service[#{service}]" do
+                            notify = catalogue.resource('group', 'puppet').send(:parameters)[:notify]
+                            regex = Regexp.new("#{service}")
+                            expect(notify.find { |x| x.to_s =~ Regexp.new(regex)}).to be_truthy
+                          end
+                        end
+                      end
+
+                      firewall = value['firewall_rules']
+                      unless (firewall == nil)
+                        firewall.each do |rule|
+                          let(:params) {
+                            {
+                              'firewall' => true
+                            }
+                          }
+                          it { is_expected.to contain_iptables__listen__tcp_stateful("#{key} - #{rule['proto']} - #{rule['port']}").with({ 'dports' => rule['port']})}
+                        end
+                      end
+                    end
+                  end
+                end
+              end
+              if ($pe_mode == true)
+                context "with pupmod::master defined" do
+                  let(:pre_condition) {
+                    '
+                      include ::puppet_enterprise
+                      include ::puppet_enterprise::profile::master
+                      class { "::pupmod":
+                        mock => true
+                      }
+                      include pupmod::master
+                    '
+                  }
+                  #                   it { is_expected.to compile }
+                  it { is_expected.to compile.and_raise_error(/.*pupmod::master is NOT supported on PE masters. Please remove the pupmod::master classification from hiera or the puppet console before proceeding.*/) }
+                end
+                context "with pupmod::master not defined" do
+                  let(:pre_condition) {
+                    '
+                      include ::puppet_enterprise
+                      include ::puppet_enterprise::profile::master
+                      class { "::pupmod":
+                        mock => true
+                      }
+                    '
+                  }
+                  it { is_expected.to compile }
+                  it { is_expected.to contain_class("pupmod::master::sysconfig")}
+                  it { is_expected.to contain_class("pupmod::params")}
+                  it { is_expected.to contain_file("/opt/puppetlabs/puppet/cache/pserver_tmp")}
+                  it { is_expected.to contain_pe_ini_subsetting("pupmod::master::sysconfig::javatempdir")}
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/hieradata/hiera.yaml
+++ b/spec/fixtures/hieradata/hiera.yaml
@@ -1,0 +1,9 @@
+---
+:backends:
+- yaml
+:yaml:
+  :datadir: "/data/spec/fixtures/hieradata"
+:hierarchy:
+- "%{custom_hiera}"
+- "%{module_name}"
+- default

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -143,6 +143,9 @@ RSpec.configure do |c|
     FileUtils.rm_rf(@spec_global_env_temp)
     @spec_global_env_temp = nil
   end
+  c.after(:suite) do
+#    RSpec::Puppet::Coverage.report!(100)
+  end
 end
 
 Dir.glob("#{RSpec.configuration.module_path}/*").each do |dir|


### PR DESCRIPTION
* Create pupmod::pass_two defined type, that inspects
  the existing catalog, and depending upon whether
  any PE classes are included, reconfigures pupmod
  to match
* Use pe_ini_subsetting for pupmod::master::sysconfig
* Always use the puppet group for both agents and
  masters
* Fix auditd global catalyst
* Add module data, and add a class lookup hash
  to specify firewall rules, users, and services

SIMP-2504 #close