### PR TITLE
(SIMP-2679) Use extra_java_args from manifest

### DIFF
--- a/spec/classes/master/data/puppetserver.txt
+++ b/spec/classes/master/data/puppetserver.txt
@@ -2,7 +2,7 @@
 JAVA_BIN="/usr/bin/java"
 
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
-JAVA_ARGS="-Xms245m -Xmx245m -Djava.io.tmpdir=/opt/puppetlabs/puppet/cache/pserver_tmp"
+JAVA_ARGS="-Xms245m -Xmx245m -Djava.io.tmpdir=/opt/puppetlabs/puppet/cache/pserver_tmp "
 
 # These normally shouldn't need to be edited if using OS packages
 USER="puppet"

--- a/templates/etc/sysconfig/puppetserver.erb
+++ b/templates/etc/sysconfig/puppetserver.erb
@@ -11,7 +11,9 @@ else
   java_start_memory = @java_start_memory
 end
 
-extra_java_args = @extra_java_args.join(' ')
+if !@extra_java_args.empty?
+  extra_java_args = @extra_java_args.join(' ')
+end
 -%>
 # Location of your Java binary (version 7 or higher)
 JAVA_BIN="<%= @java_bin %>"

--- a/templates/etc/sysconfig/puppetserver.erb
+++ b/templates/etc/sysconfig/puppetserver.erb
@@ -10,12 +10,14 @@ if !@java_start_memory || @java_start_memory.empty?
 else
   java_start_memory = @java_start_memory
 end
+
+extra_java_args = @extra_java_args.join(' ')
 -%>
 # Location of your Java binary (version 7 or higher)
 JAVA_BIN="<%= @java_bin %>"
 
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
-JAVA_ARGS="-Xms<%= java_start_memory %> -Xmx<%= java_max_memory %> -Djava.io.tmpdir=<%= @_java_temp_dir %>"
+JAVA_ARGS="-Xms<%= java_start_memory %> -Xmx<%= java_max_memory %> -Djava.io.tmpdir=<%= @_java_temp_dir %> <%= extra_java_args %>"
 
 # These normally shouldn't need to be edited if using OS packages
 USER="puppet"

--- a/templates/etc/sysconfig/puppetserver.erb
+++ b/templates/etc/sysconfig/puppetserver.erb
@@ -11,7 +11,7 @@ else
   java_start_memory = @java_start_memory
 end
 
-if !@extra_java_args.empty?
+if @extra_java_args != nil
   extra_java_args = @extra_java_args.join(' ')
 end
 -%>


### PR DESCRIPTION
Fixed an oversight where extra_java_args was present in the pupmod::master::sysconfig manifest, but it wasn't referenced anywhere in the template.