### PR TITLE
(SIMP-2745) Fix tempdir on PE 2016.5.1

### DIFF
--- a/manifests/master/sysconfig.pp
+++ b/manifests/master/sysconfig.pp
@@ -67,7 +67,6 @@ class pupmod::master::sysconfig (
     else {
       $_java_temp_dir = $java_temp_dir
     }
-
     file { $_java_temp_dir:
       ensure => 'directory',
       owner  => $user,
@@ -84,15 +83,19 @@ class pupmod::master::sysconfig (
       }
     }
     if ($server_distribution == 'PE') {
-      pe_ini_subsetting { 'pupmod::master::sysconfig::javatempdir':
-        path              => '/etc/sysconfig/pe-puppetserver',
-        section           => '',
-        setting           => 'JAVA_ARGS',
-        subsetting        => '-Djava.io.tmpdir',
-        quote_char        => '"',
-        value             => "=${_java_temp_dir}",
-        key_val_separator => '=',
-        notify            => Service[$service],
+      if (has_key($facts, 'pe_build')) {
+        if (SemVer($facts['pe_build']) < SemVer("2016.4.0")) {
+          pe_ini_subsetting { 'pupmod::master::sysconfig::javatempdir':
+            path              => '/etc/sysconfig/pe-puppetserver',
+            section           => '',
+            setting           => 'JAVA_ARGS',
+            subsetting        => '-Djava.io.tmpdir',
+            quote_char        => '"',
+            value             => "=${_java_temp_dir}",
+            key_val_separator => '=',
+            notify            => Service[$service],
+          }
+        }
       }
     }
   }

--- a/spec/defines/pass_two_spec.rb
+++ b/spec/defines/pass_two_spec.rb
@@ -178,8 +178,32 @@ describe 'pupmod::pass_two' do
                   it { is_expected.to compile }
                   it { is_expected.to contain_class("pupmod::master::sysconfig")}
                   it { is_expected.to contain_class("pupmod::params")}
-                  it { is_expected.to contain_file("/opt/puppetlabs/puppet/cache/pserver_tmp")}
-                  it { is_expected.to contain_pe_ini_subsetting("pupmod::master::sysconfig::javatempdir")}
+                  {
+                    "2015.1.1" => true,
+                    "2015.20.1" => true,
+                    "2016.1.0" => true,
+                    "2016.2.0" => true,
+                    "2016.4.0" => false,
+                    "2016.4.1" => false,
+                    "2016.5.1" => false,
+                    "2017.1.0" => false,
+                    "2017.20.1" => false,
+                    "2018.1.0" => false,
+                    "2020.1.0" => false,
+                    "2021.1.0" => false,
+                  }.each do |pe_version, tmpdir|
+                    it { is_expected.to contain_file("/opt/puppetlabs/puppet/cache/pserver_tmp")}
+                    context "when pe_version == #{pe_version}" do
+                      let (:facts) do
+                        { "pe_build" => pe_version }.merge(facts)
+                      end
+                      if (tmpdir == true)
+                        it { is_expected.to contain_pe_ini_subsetting("pupmod::master::sysconfig::javatempdir")}
+                      else
+                        it { is_expected.to_not contain_pe_ini_subsetting("pupmod::master::sysconfig::javatempdir")}
+                      end
+                    end
+                  end
                 end
               end
             end


### PR DESCRIPTION
One of the few configuration changes we make to the puppetserver config
file is changing the temporary directory since /tmp is noexec. Add a
semver based conditional test, and a test matrix to make sure that it
parses pe_build as necessary.

SIMP-2745 #close