### PR TITLE
(SIMP-2702) Added lock to agent cron runs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Mar 06 2017 Nick Markowski <nmarkowski@keywcorp.com> - 7.1.1-0
+- Puppet agent runs in bootstrap and puppetagent_cron are now mutually
+  exclusive, with the addition of flock logic.
+
 * Wed Mar 01 2017 Nick Miller <nick.miller@onyxpoint.com> - 7.1.1-0
 - The previous audit rules relied on the puppet user existing, but in
   newer versions of puppet, the puppet user only exists on the

--- a/manifests/agent/cron.pp
+++ b/manifests/agent/cron.pp
@@ -79,7 +79,7 @@ class pupmod::agent::cron (
 
   if $minute == 'nil' {
     cron { 'puppetagent':
-      command => 'flock -w .1 /var/puppetagent_cron.lock /usr/local/bin/puppetagent_cron.sh',
+      command => 'flock -w .1 /var/lock/puppetagent_cron /usr/local/bin/puppetagent_cron.sh',
       user    => 'root',
       minute  => "*/${interval}",
       require => File['/usr/local/bin/puppetagent_cron.sh']
@@ -93,7 +93,7 @@ class pupmod::agent::cron (
       $l_minute = $minute
     }
     cron { 'puppetagent':
-      command  => 'flock -w .1 /var/puppetagent_cron.lock /usr/local/bin/puppetagent_cron.sh',
+      command  => 'flock -w .1 /var/lock/puppetagent_cron /usr/local/bin/puppetagent_cron.sh',
       user     => 'root',
       minute   => $l_minute,
       hour     => $hour,

--- a/manifests/agent/cron.pp
+++ b/manifests/agent/cron.pp
@@ -79,7 +79,7 @@ class pupmod::agent::cron (
 
   if $minute == 'nil' {
     cron { 'puppetagent':
-      command => '/usr/local/bin/puppetagent_cron.sh',
+      command => 'flock -w .1 /var/puppetagent_cron.lock /usr/local/bin/puppetagent_cron.sh',
       user    => 'root',
       minute  => "*/${interval}",
       require => File['/usr/local/bin/puppetagent_cron.sh']
@@ -93,7 +93,7 @@ class pupmod::agent::cron (
       $l_minute = $minute
     }
     cron { 'puppetagent':
-      command  => '/usr/local/bin/puppetagent_cron.sh',
+      command  => 'flock -w .1 /var/puppetagent_cron.lock /usr/local/bin/puppetagent_cron.sh',
       user     => 'root',
       minute   => $l_minute,
       hour     => $hour,


### PR DESCRIPTION
- Puppet agent runs in bootstrap and puppetagent_cron are now mutually
  exclusive, with the addition of flock logic.

SIMP-2702 #comment added agent locking logic