### PR TITLE
(SIMP-2817) Updated puppetagent_cron

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 * Wed Mar 08 2017 Nick Markowski <nmarkowski@keywcorp.com> - 7.2.0-0
 - Updated puppetagent_cron:
--  Added `enable_agent` param so users can clearly specify when they wish
+-  Added `break_puppet_lock` param so users can clearly specify when they wish
    to forcibly enable the puppet agent.
 -  Added `max_disable_time param`. Updated logic to determine when to
    forcibly enable a puppet agent, and moved logic into cron.pp for

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+* Wed Mar 08 2017 Nick Markowski <nmarkowski@keywcorp.com> - 7.2.0-0
+- Updated puppetagent_cron:
+-  Added `enable_agent` param so users can clearly specify when they wish
+   to forcibly enable the puppet agent.
+-  Added `max_disable_time param`. Updated logic to determine when to
+   forcibly enable a puppet agent, and moved logic into cron.pp for
+   user-friendliness.
+-  Set maxruntime default of 4 hours
+
 * Wed Mar 01 2017 Nick Miller <nick.miller@onyxpoint.com> - 7.1.1-0
 - The previous audit rules relied on the puppet user existing, but in
   newer versions of puppet, the puppet user only exists on the

--- a/manifests/agent/cron.pp
+++ b/manifests/agent/cron.pp
@@ -115,9 +115,11 @@ class pupmod::agent::cron (
     $_max_disable_time = $max_disable_time
   }
   else {
-    if $::splaylimit {
+    $_splaylimit = getvar('pupmod::splaylimit')
+
+    if $_splaylimit {
       # This assumes splay is in seconds.
-      $_max_disable_time = $_max_disable_base + ($::splaylimit / 60)
+      $_max_disable_time = $_max_disable_base + ($_splaylimit / 60)
     }
     else {
       $_max_disable_time = $_max_disable_base

--- a/manifests/agent/cron.pp
+++ b/manifests/agent/cron.pp
@@ -1,69 +1,81 @@
-# This class configures the cron settings for a non-daemonized puppet
-# client.
+# This class configures the cron settings for a non-daemonized puppet client
 #
 # @param interval
-#   The cron iteration time (in minutes) for running puppet.
-#   This applies the standard */$interval style syntax from cron.
-#   See crontab(5) for additional details.
+#   The cron iteration time (in minutes) for running puppet
 #
-#   Note: This is overridden if $minute is set to anything other
-#   than 'nil'.  If this is the case, it is assumed that you want finer
-#   control over your puppet run.
+#   * This applies the standard ``*/$interval`` style syntax from cron
+#
+#   * See ``crontab(5)`` for additional details
+#
+#   * NOTE: This is overridden if ``$minute`` is set to anything other than
+#     ``nil`` or ``rand``.  If this is the case, it is assumed that you want
+#     finer control over your puppet run.
 #
 # @param minute_base
-#   The default artifact to use to auto-generate a cron interval.
+#   The default artifact to use to auto-generate a cron interval
 #
-#   The default of $::ipaddress is used to provide a reasonable guess at
-#   spreading the puppet runs across all of your systems. However, you
-#   can set this to *anything* that you like.
+#   * The default of ``$::ipaddress`` is used to provide a reasonable guess at
+#     spreading the puppet runs across all of your systems. However, you can
+#     set this to *anything* that you like.
 #
-#   Use $::ipaddress_eth0 to generate the entry from the eth0 IP Address
-#   Use $::uniqueid to generate the entry from the system UUID
+#   * Use ``$::ipaddress_eth0`` to generate the entry from the eth0 IP Address
 #
-#   If this is the *same* resolved value on all of your systems then
-#   your systems will have the *same* run interval.
+#   * Use ``$::uniqueid`` to generate the entry from the system UUID
+#
+#   * WARNING: If this is the *same* resolved value on all of your systems then
+#     your systems will have the *same* run interval.
 #
 # @param run_timeframe
-#   The time frame within which you wish to run the puppet agent. This
-#   directly translates to the minute field of the cron job so this
-#   should probably be left at 60.
+#   The time frame within which you wish to run the puppet agent
+#
+#   * This directly translates to the minute field of the cron job so this
+#     should probably be left at 60
 #
 # @param runs_per_timeframe
-#   The number of times, per $timeframe, that you want to run the Puppet
+#   The number of times, per ``$timeframe``, that you want to run the Puppet
 #   Agent.
 #
 # @param minute
-#   The 'minute' value for the crontab entry.
-#   Set to 'nil' if you want to use $interval.
+#   The ``minute`` value for the crontab entry
+#
+#   Set to ``nil`` if you want to use $interval
 #
 # @param hour
-#   The 'hour' value for the crontab entry.
-#   Not used if using $interval.
+#   The ``hour`` value for the crontab entry
+#
+#   Not used if using ``$interval``
 #
 # @param monthday
-#   The 'monthday' value for the crontab entry.
-#   Not used if using $interval.
+#   The ``monthday`` value for the crontab entry
+#
+#   * Not used if using ``$interval``
 #
 # @param month
-#   The 'month' value for the crontab entry.
-#   Not used if using $interval.
+#   The ``month`` value for the crontab entry
+#
+#   * Not used if using ``$interval``
 #
 # @param weekday
-#   The 'weekday' value for the crontab entry.
-#   Not used if using $interval.
+#   The ``weekday`` value for the crontab entry
+#
+#   * Not used if using ``$interval``
 #
 # @param maxruntime
 #   How long (in minutes) a puppet agent will be allowed to run before being
-#   forcibly stopped.  Defaults to 240 min (4 hours).
+#   forcibly stopped
 #
-# @param enable_agent
-#   If true, forcibly enable the puppet agent if it has been disabled for
-#   $max_disable_time.  If false, never force enable.
+# @param break_puppet_lock
+#   Forcibly enable the puppet agent if it has been disabled for
+#   ``$max_disable_time``
+#
+#   * This is enabled by default so that the system can remain in a
+#     self-healing state
 #
 # @param max_disable_time
 #   How long (in minutes) a puppet agent will be allowed to remain disabled
-#   before being forcibly enabled.  This only takes effect if $enable_agent
-#   is true.
+#   before being forcibly enabled
+#
+#   * This only takes effect if ``$break_puppet_lock`` is true
 #
 class pupmod::agent::cron (
   Integer[0]            $interval           = 30,
@@ -76,7 +88,7 @@ class pupmod::agent::cron (
   Variant[Array,String] $month              = '*',
   Variant[Array,String] $weekday            = '*',
   Integer[1]            $maxruntime         = 240,
-  Boolean               $enable_agent       = true,
+  Boolean               $break_puppet_lock  = true,
   Optional[Integer[1]]  $max_disable_time   = undef
 ) {
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pupmod",
-  "version": "7.1.1",
+  "version": "7.2.0",
   "author": "SIMP Team",
   "summary": "A puppet module to manage puppetserver and puppet agents",
   "license": "Apache-2.0",

--- a/spec/classes/agent/cron_spec.rb
+++ b/spec/classes/agent/cron_spec.rb
@@ -11,7 +11,7 @@ describe 'pupmod::agent::cron' do
         let(:params) {{ :interval => 60 }}
 
         it { is_expected.to create_class('pupmod::agent::cron') }
-        it { is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/-gt 3600/) }
+        it { is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/-gt 14400/) }
         it { is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(
           /service puppet stop > \/dev\/null 2>&1/
         )}
@@ -50,26 +50,10 @@ describe 'pupmod::agent::cron' do
           it { is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/-gt 600/) }
         end
 
-        context 'set_max_age to never unlock' do
-          let(:params) {{ :maxruntime => 0 }}
-          it { is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/"0" == "0"/) }
-        end
-
-        context 'when pupmod::splay is true' do
-          let(:facts) do
-            os_facts.merge({'custom_hiera'=>'pupmod_splay_is_true'})
-          end
-          let(:params) {{ }}
-          splay = Puppet[:splaylimit] + 1800 + 10
-          it { is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/-gt #{splay}/) }
-        end
-
-        context 'when pupmod::splay is true but maxruntime is disabled' do
-          let(:facts) { os_facts.merge( {'custom_hiera'=>'pupmod_splay_is_true'} )}
-          let(:params) {{ :maxruntime => 0 }}
-          splay = Puppet[:splaylimit] + 10
-            it { is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/"0" == "0"/) }
-            it { is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/-gt #{splay}/) }
+        context 'disable break_puppet_lock' do
+          let(:params) {{ :break_puppet_lock => false }}
+          it { is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/handles puppet processes which have been running longer than maxruntime/) }
+          it { is_expected.to_not contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/handles forcibly enabling puppet agent/) }
         end
       end
     end

--- a/templates/usr/local/bin/puppetagent_cron.erb
+++ b/templates/usr/local/bin/puppetagent_cron.erb
@@ -8,7 +8,7 @@ filedate=0;
 puppet_run_lockfile="$(puppet config print agent_catalog_run_lockfile)";
 puppet_disable_lockfile="$(puppet config print agent_disabled_lockfile)";
 
-<% if @enable_agent -%>
+<% if @break_puppet_lock -%>
 # This handles forcibly enabling puppet agent if _max_disable_time is exceeded.
 if [ -f "${puppet_disable_lockfile}" ]; then
 

--- a/templates/usr/local/bin/puppetagent_cron.erb
+++ b/templates/usr/local/bin/puppetagent_cron.erb
@@ -1,16 +1,3 @@
-<%
-unless @maxruntime
-  # Limit this to 4 hours, if users want more than that, they'll just
-  # need to set maxruntime themselves.
-  maxage = [@interval.to_i * 60,14400].min
-else
-  maxage = @maxruntime.to_i * 60
-end
-
-if scope.lookupvar('::pupmod::splay')
-  maxage = maxage + scope.lookupvar('::pupmod::splaylimit').to_i + 10
-end
--%>
 #!/bin/bash
 
 PATH="/opt/puppetlabs/bin:/usr/kerberos/sbin:/usr/kerberos/bin:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin";
@@ -18,20 +5,15 @@ PATH="/opt/puppetlabs/bin:/usr/kerberos/sbin:/usr/kerberos/bin:/usr/local/sbin:/
 now=0;
 filedate=0;
 
-puppet_lockfile="$(puppet config print agent_disabled_lockfile)";
 puppet_run_lockfile="$(puppet config print agent_catalog_run_lockfile)";
+puppet_disable_lockfile="$(puppet config print agent_disabled_lockfile)";
 
-# This handles willful disabling of Puppet and service status (not cron runs)
-if [ -f "${puppet_lockfile}" ]; then
-
-  # Exit if maxruntime == 0.  This means that you wish to never forcibly unlock
-  # the system.
-  if [ "<%= @maxruntime %>" == "0" ]; then
-    exit 0;
-  fi
+<% if @enable_agent -%>
+# This handles forcibly enabling puppet agent if _max_disable_time is exceeded.
+if [ -f "${puppet_disable_lockfile}" ]; then
 
   now=$(date "+%s");
-  filedate=$(stat --printf="%Z" ${puppet_lockfile});
+  filedate=$(stat --printf="%Z" ${puppet_disable_lockfile});
 
   /sbin/service puppet status &> /dev/null;
   pup_status=$?;
@@ -48,31 +30,32 @@ if [ -f "${puppet_lockfile}" ]; then
   # about it.
   # If you want to disable puppet then disable the cron job and the service and
   # set the lockfile.
-  if [[ ${pup_status} -ne 0 && $(( ${now} - ${filedate} )) -gt <%= maxage %> ]]; then
-    /bin/logger -s -p 'local6.warn' -t 'puppetd' "Puppet disable forcibly unlocked.";
-    /bin/rm -f "${puppet_lockfile}";
+  if [[ ${pup_status} -ne 0 && $(( ${now} - ${filedate} )) -gt <%= @_max_disable_time * 60 %> ]]; then
+    /bin/logger -s -p 'local6.warn' -t 'puppet' "Puppet disable forcibly unlocked.";
+    /bin/rm -f "${puppet_disable_lockfile}";
   fi
 fi
+<% end -%>
 
-# Get the process listing to check for "hung" cron job runs
-pup_status="$(ps -p "$(pidof ruby)" -o args --no-headers 2> /dev/null | grep 'puppet agent')";
-
-# This handles "hung" puppet processes
+# This handles puppet processes which have been running longer than maxruntime
 if [ -f "${puppet_run_lockfile}" ]; then
+
+  # Get the process listing to check for "hung" cron job runs
+  pup_status="$(ps -p "$(pidof ruby)" -o args --no-headers 2> /dev/null | grep 'puppet agent')";
 
   now=$(date "+%s");
   filedate=$(stat --printf="%Z" ${puppet_run_lockfile});
 
   # If we've gotten here, then Puppet has not completed within threshold
-  if [[ -n "${pup_status}" && $(( ${now} - ${filedate} )) -gt <%= maxage %> ]]; then
+  if [[ -n "${pup_status}" && $(( ${now} - ${filedate} )) -gt <%= @maxruntime * 60 %> ]]; then
     pkill puppet;
     wait;
-    /bin/logger -s -p 'local6.warn' -t 'puppetd' "Puppet processes forcibly killed.";
+    /bin/logger -s -p 'local6.warn' -t 'puppet' "Puppet processes forcibly killed.";
     /bin/rm -f "${puppet_run_lockfile}";
   fi
 fi
 
 # Run Puppet if we don't have any locks
-if [ ! -f "${puppet_lockfile}" ] && [ ! -f "${puppet_run_lockfile}" ]; then
+if [ ! -f "${puppet_disable_lockfile}" ] && [ ! -f "${puppet_run_lockfile}" ]; then
   puppet agent --onetime --no-daemonize --no-show_diff;
 fi

--- a/templates/usr/local/bin/puppetagent_cron.erb
+++ b/templates/usr/local/bin/puppetagent_cron.erb
@@ -48,7 +48,7 @@ if [ -f "${puppet_run_lockfile}" ]; then
 
   # If we've gotten here, then Puppet has not completed within threshold
   if [[ -n "${pup_status}" && $(( ${now} - ${filedate} )) -gt <%= @maxruntime * 60 %> ]]; then
-    pkill puppet;
+    pkill -x puppet;
     wait;
     /bin/logger -s -p 'local6.warn' -t 'puppet' "Puppet processes forcibly killed.";
     /bin/rm -f "${puppet_run_lockfile}";


### PR DESCRIPTION
- Updated puppetagent_cron:
-  Added `enable_agent` param so users can clearly specify when they wish
   to forcibly enable the puppet agent.
-  Added `max_disable_time param`. Updated logic to determine when to
   forcibly enable a puppet agent, and moved logic into cron.pp for
   user-friendliness.
-  Set maxruntime default of 4 hours

SIMP-2817 #close
SIMP-2702 #comment updated puppetagent_cron