### PR TITLE
(SIMP-2972) Add 'package_ensure' parameter to pupmod and pupmod::master

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue Apr 04 2017 Dylan Cochran <dylan.cochran@onyxpoint.com> - 7.3.0-0
+- Add 'package_ensure' to allow users to specify that they want to use 'latest' or 'installed'
+
 * Wed Mar 08 2017 Nick Markowski <nmarkowski@keywcorp.com> - 7.2.0-0
 - Updated puppetagent_cron:
 -  Added `break_puppet_lock` param so users can clearly specify when they wish

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -128,6 +128,9 @@
 # @param pe_classlist
 #   Hash of pe classes and assorted metadata.
 #
+# @param package_ensure
+#   String used to specify 'latest', 'installed', or a specific version of the puppet-agent package
+#
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class pupmod (
@@ -160,6 +163,7 @@ class pupmod (
   Boolean                                $fips                 = simplib::lookup('simp_options::fips', { 'default_value' => false }),
   Boolean                                $firewall             = simplib::lookup('simp_options::firewall', { 'default_value' => false }),
   Hash                                   $pe_classlist         = {},
+  String                                 $package_ensure       = 'latest',
   Boolean                                $mock                 = false
 ) inherits pupmod::params {
   unless ($mock == true) {
@@ -181,7 +185,7 @@ class pupmod (
     if $enable_puppet_master {
       include 'pupmod::master'
     }
-    package { 'puppet-agent': ensure => 'latest' }
+    package { 'puppet-agent': ensure => $package_ensure }
 
     cron { 'puppet_crl_pull':
       command => template('pupmod/commands/crl_download.erb'),
@@ -366,3 +370,4 @@ class pupmod (
     }
   }
 }
+# vim: set expandtab ts=2 sw=2:

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -92,6 +92,8 @@
 #   A syslog severity string limiting the messages reported. Be aware that
 #   anything above 'WARN' will provide a massive amount of logs at each puppet
 #   run.
+# @param package_ensure
+#   String used to specify either 'latest', 'installed', or a specific version of the puppetserver package
 # @param mock
 #   DO NOT USE. needed for rspec testing
 #
@@ -133,6 +135,7 @@ class pupmod::master (
   String                         $syslog_facility       = 'LOCAL6',
   String                         $syslog_message_format = '%logger[%thread]: %msg',
   Pupmod::LogLevel               $log_level             = 'WARN',
+  String                         $package_ensure                = 'latest',
   Boolean                        $mock                  = false
 ) inherits ::pupmod::params {
   if ($mock == false) {

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -135,7 +135,7 @@ class pupmod::master (
   String                         $syslog_facility       = 'LOCAL6',
   String                         $syslog_message_format = '%logger[%thread]: %msg',
   Pupmod::LogLevel               $log_level             = 'WARN',
-  String                         $package_ensure                = 'latest',
+  String                         $package_ensure        = 'latest',
   Boolean                        $mock                  = false
 ) inherits ::pupmod::params {
   if ($mock == false) {

--- a/manifests/master/base.pp
+++ b/manifests/master/base.pp
@@ -62,7 +62,7 @@ class pupmod::master::base {
 
 
   package { $::pupmod::master::service:
-    ensure => 'latest',
+    ensure => $::pupmod::master::package_ensure,
     before => File[$::pupmod::confdir],
     notify => Service[$::pupmod::master::service]
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pupmod",
-  "version": "7.2.0",
+  "version": "7.3.0",
   "author": "SIMP Team",
   "summary": "A puppet module to manage puppetserver and puppet agents",
   "license": "Apache-2.0",
@@ -54,10 +54,6 @@
     {
       "name": "puppet",
       "version_requirement": ">= 4.x"
-    },
-    {
-      "name": "pe",
-      "version_requirement": ">= 2016.2.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Add an 'package_ensure' parameter that allows the admin to specify the specific
version of puppet-agent or puppetserver they want the module to install.

SIMP-2972 #close