### PR TITLE
(SIMP-3049) SIMP should use the puppetlabs-puppet_authorization modul…

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,27 +3,15 @@ fixtures:
   repositories:
     apache: https://github.com/simp/pupmod-simp-apache
     auditd: https://github.com/simp/pupmod-simp-auditd
-    augeasproviders:
-      repo: https://github.com/simp/augeasproviders
-      branch: simp-master
-    augeasproviders_base:
-      repo: https://github.com/simp/augeasproviders_base
-      branch: simp-master
-    augeasproviders_core:
-      repo: https://github.com/simp/augeasproviders_core
-      branch: simp-master
-    augeasproviders_grub:
-      repo: https://github.com/simp/augeasproviders_grub
-      branch: simp-master
-    augeasproviders_puppet:
-      repo: https://github.com/simp/augeasproviders_puppet
-      branch: simp-master
+    augeasproviders: https://github.com/simp/augeasproviders
+    augeasproviders_base: https://github.com/simp/augeasproviders_base
+    augeasproviders_core: https://github.com/simp/augeasproviders_core
+    augeasproviders_grub: https://github.com/simp/augeasproviders_grub
+    augeasproviders_puppet: https://github.com/simp/augeasproviders_puppet
     haveged:
       repo: https://github.com/simp/puppet-haveged
       branch: simp-master
-    inifile:
-      repo: https://github.com/simp/puppetlabs-inifile
-      branch: simp-master
+    inifile: https://github.com/simp/puppetlabs-inifile
     iptables: https://github.com/simp/pupmod-simp-iptables
     logrotate: https://github.com/simp/pupmod-simp-logrotate
     pam: https://github.com/simp/pupmod-simp-pam
@@ -37,5 +25,6 @@ fixtures:
     puppet_enterprise:
       repo: https://github.com/simp/pupmod-mock-puppet_enterprise
       ref: 0.3.0
+    puppet_authorization: https://github.com/simp/puppetlabs-puppet_authorization.git
   symlinks:
     pupmod: "#{source_dir}"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 * Mon May 22 2017 Kendall Moore <kendall.moore@onyxpoint.com> 7.3.2-0
 - Added manifest to manage simp-specific puppet master auth requirements
+- Disabled puppetserver setting to enable legacy auth.conf by default
+- Remove legacy auth.conf placed by the `puppet-agent` package
 
 * Fri May 19 2017 Nick Miller <nick.miller@onyxpoint.com> - 7.3.1-0
 - Removed deprecated `audit` metaparameter

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon May 22 2017 Kendall Moore <kendall.moore@onyxpoint.com> 7.3.2-0
+- Added manifest to manage simp-specific puppet master auth requirements
+
 * Fri May 19 2017 Nick Miller <nick.miller@onyxpoint.com> - 7.3.1-0
 - Removed deprecated `audit` metaparameter
 

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -97,46 +97,96 @@
 # @param mock
 #   DO NOT USE. needed for rspec testing
 #
+# @param auth_conf_path
+#   Type:    Stdlib::AbsolutePath
+#   Default: /etc/puppetlabs/puppetserver/conf.d/auth.conf
+#   The location to the puppet master's auth.conf
+#
+# @param pki_cacerts_all
+#   Type:    Boolean
+#   Default: true
+#   If enabled, allow PKI cacerts files from SIMP PKI module from all hosts
+#
+# @param pki_mcollective_all
+#   Type:    Boolean
+#   Default: true
+#   If enabled, allow SIMP site_files cacerts access from all hosts
+#
+# @param site_files_cacerts_all
+#   Type:    Boolean
+#   Default: true
+#   If enabled, allow MCO files from SIMP PKI module access from all hosts
+#
+# @param site_files_mcollective_all
+#   Type:    Boolean
+#   Default: true
+#   If enabled, allow SIMP site_files PKI mcollective access from all hosts
+#
+# @param keydist_from_host
+#   Type:    Boolean
+#   Default: true
+#   If enabled, allow SIMP PKI keydist module access from specific host
+#
+# @param pki_keytabs_from_host
+#   Type:    Boolean
+#   Default: true
+#   If enabled, allow SIMP site_files PKI keytabs access from specific host
+#
+# @param krb5_keytabs_from_host
+#   Type:    Boolean
+#   Default: true
+#   If enabled, allow SIMP site_files krb5 keytabs access from specific host
+#
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class pupmod::master (
-  Simplib::IP                    $bind_address          = '0.0.0.0',
-  Simplib::IP                    $ca_bind_address       = '0.0.0.0',
-  Boolean                        $auditd                = simplib::lookup('simp_options::auditd', { 'default_value' => false }),
-  Simplib::Port                  $ca_port               = simplib::lookup('simp_options::puppet::ca_port', { 'default_value' => 8141 }),
-  Simplib::NetList               $trusted_nets          = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1','::1'] }),
-  String                         $server_distribution   = simplib::lookup('simp_options::puppet::server_distribution', { 'default_value' => 'PC1' } ),
-  Pupmod::CaTTL                  $ca_ttl                = '10y',
-  Boolean                        $daemonize             = true,
-  Boolean                        $enable_ca             = true,
-  Boolean                        $enable_master         = true,
-  Stdlib::AbsolutePath           $environmentpath       = $::pupmod::params::puppet_config['environmentpath'],
-  Boolean                        $freeze_main           = false,
-  Simplib::Port                  $masterport            = 8140,
-  Stdlib::AbsolutePath           $puppet_confdir        = $::pupmod::params::puppet_config['confdir'],
-  Stdlib::AbsolutePath           $confdir               = $::pupmod::params::master_config['confdir'],
-  Stdlib::AbsolutePath           $codedir               = $::pupmod::params::master_config['codedir'],
-  Stdlib::AbsolutePath           $vardir                = $::pupmod::params::master_config['vardir'],
-  Stdlib::AbsolutePath           $rundir                = $::pupmod::params::master_config['rundir'],
-  Stdlib::AbsolutePath           $logdir                = $::pupmod::params::master_config['logdir'],
-  Stdlib::AbsolutePath           $ssldir                = $::pupmod::params::puppet_config['ssldir'],
-  Boolean                        $use_legacy_auth_conf  = true,
-  Boolean                        $firewall              = simplib::lookup('simp_options::firewall', { 'default_value' => false }),
-  Array[Simplib::Host]           $ca_status_whitelist   = [$facts['fqdn']],
-  Optional[Stdlib::AbsolutePath] $ruby_load_path        = undef,
-  Integer                        $max_active_instances  = ($facts['processors']['count'] + 2),
-  Array[String]                  $ssl_protocols         = ['TLSv1', 'TLSv1.1', 'TLSv1.2'],
-  Optional[Array]                $ssl_cipher_suites     = undef,
-  Boolean                        $enable_profiler       = false,
-  Array[Simplib::Hostname]       $admin_api_whitelist   = [$facts['fqdn']],
-  String                         $admin_api_mountpoint  = '/puppet-admin-api',
-  Boolean                        $log_to_file           = false,
-  Boolean                        $syslog                = simplib::lookup('simp_options::syslog', { 'default_value' => false }),
-  String                         $syslog_facility       = 'LOCAL6',
-  String                         $syslog_message_format = '%logger[%thread]: %msg',
-  Pupmod::LogLevel               $log_level             = 'WARN',
-  String                         $package_ensure        = 'latest',
-  Boolean                        $mock                  = false
+  Simplib::IP                    $bind_address                    = '0.0.0.0',
+  Simplib::IP                    $ca_bind_address                 = '0.0.0.0',
+  Boolean                        $auditd                          = simplib::lookup('simp_options::auditd', { 'default_value' => false }),
+  Simplib::Port                  $ca_port                         = simplib::lookup('simp_options::puppet::ca_port', { 'default_value' => 8141 }),
+  Simplib::NetList               $trusted_nets                    = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1','::1'] }),
+  String                         $server_distribution             = simplib::lookup('simp_options::puppet::server_distribution', { 'default_value' => 'PC1' } ),
+  Pupmod::CaTTL                  $ca_ttl                          = '10y',
+  Boolean                        $daemonize                       = true,
+  Boolean                        $enable_ca                       = true,
+  Boolean                        $enable_master                   = true,
+  Stdlib::AbsolutePath           $environmentpath                 = $::pupmod::params::puppet_config['environmentpath'],
+  Boolean                        $freeze_main                     = false,
+  Simplib::Port                  $masterport                      = 8140,
+  Stdlib::AbsolutePath           $puppet_confdir                  = $::pupmod::params::puppet_config['confdir'],
+  Stdlib::AbsolutePath           $confdir                         = $::pupmod::params::master_config['confdir'],
+  Stdlib::AbsolutePath           $codedir                         = $::pupmod::params::master_config['codedir'],
+  Stdlib::AbsolutePath           $vardir                          = $::pupmod::params::master_config['vardir'],
+  Stdlib::AbsolutePath           $rundir                          = $::pupmod::params::master_config['rundir'],
+  Stdlib::AbsolutePath           $logdir                          = $::pupmod::params::master_config['logdir'],
+  Stdlib::AbsolutePath           $ssldir                          = $::pupmod::params::puppet_config['ssldir'],
+  Boolean                        $use_legacy_auth_conf            = true,
+  Boolean                        $firewall                        = simplib::lookup('simp_options::firewall', { 'default_value' => false }),
+  Array[Simplib::Host]           $ca_status_whitelist             = [$facts['fqdn']],
+  Optional[Stdlib::AbsolutePath] $ruby_load_path                  = undef,
+  Integer                        $max_active_instances            = ($facts['processors']['count'] + 2),
+  Array[String]                  $ssl_protocols                   = ['TLSv1', 'TLSv1.1', 'TLSv1.2'],
+  Optional[Array]                $ssl_cipher_suites               = undef,
+  Boolean                        $enable_profiler                 = false,
+  Array[Simplib::Hostname]       $admin_api_whitelist             = [$facts['fqdn']],
+  String                         $admin_api_mountpoint            = '/puppet-admin-api',
+  Boolean                        $log_to_file                     = false,
+  Boolean                        $syslog                          = simplib::lookup('simp_options::syslog', { 'default_value' => false }),
+  String                         $syslog_facility                 = 'LOCAL6',
+  String                         $syslog_message_format           = '%logger[%thread]: %msg',
+  Pupmod::LogLevel               $log_level                       = 'WARN',
+  String                         $package_ensure                  = 'latest',
+  Boolean                        $mock                            = false,
+  Boolean                        $enable_simp_master_auth         = true,
+  Stdlib::AbsolutePath           $auth_conf_path                  = '/etc/puppetlabs/puppetserver/conf.d/auth.conf',
+  Boolean                        $auth_pki_cacerts_all            = true,
+  Boolean                        $auth_pki_mcollective_all        = true,
+  Boolean                        $auth_site_files_cacerts_all     = true,
+  Boolean                        $auth_site_files_mcollective_all = true,
+  Boolean                        $auth_keydist_from_host          = true,
+  Boolean                        $auth_pki_keytabs_from_host      = true,
+  Boolean                        $auth_krb5_keytabs_from_host     = true,
+
 ) inherits ::pupmod::params {
   if ($mock == false) {
     $service = 'puppetserver'
@@ -321,6 +371,10 @@ class pupmod::master (
       value   => false,
       #value   => $freeze_main,
       notify  => Service[$service]
+    }
+
+    if $enable_simp_master_auth {
+      include ::pupmod::master::simp_auth
     }
 
     if $auditd {

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -97,96 +97,46 @@
 # @param mock
 #   DO NOT USE. needed for rspec testing
 #
-# @param auth_conf_path
-#   Type:    Stdlib::AbsolutePath
-#   Default: /etc/puppetlabs/puppetserver/conf.d/auth.conf
-#   The location to the puppet master's auth.conf
-#
-# @param pki_cacerts_all
-#   Type:    Boolean
-#   Default: true
-#   If enabled, allow PKI cacerts files from SIMP PKI module from all hosts
-#
-# @param pki_mcollective_all
-#   Type:    Boolean
-#   Default: true
-#   If enabled, allow SIMP site_files cacerts access from all hosts
-#
-# @param site_files_cacerts_all
-#   Type:    Boolean
-#   Default: true
-#   If enabled, allow MCO files from SIMP PKI module access from all hosts
-#
-# @param site_files_mcollective_all
-#   Type:    Boolean
-#   Default: true
-#   If enabled, allow SIMP site_files PKI mcollective access from all hosts
-#
-# @param keydist_from_host
-#   Type:    Boolean
-#   Default: true
-#   If enabled, allow SIMP PKI keydist module access from specific host
-#
-# @param pki_keytabs_from_host
-#   Type:    Boolean
-#   Default: true
-#   If enabled, allow SIMP site_files PKI keytabs access from specific host
-#
-# @param krb5_keytabs_from_host
-#   Type:    Boolean
-#   Default: true
-#   If enabled, allow SIMP site_files krb5 keytabs access from specific host
-#
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class pupmod::master (
-  Simplib::IP                    $bind_address                    = '0.0.0.0',
-  Simplib::IP                    $ca_bind_address                 = '0.0.0.0',
-  Boolean                        $auditd                          = simplib::lookup('simp_options::auditd', { 'default_value' => false }),
-  Simplib::Port                  $ca_port                         = simplib::lookup('simp_options::puppet::ca_port', { 'default_value' => 8141 }),
-  Simplib::NetList               $trusted_nets                    = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1','::1'] }),
-  String                         $server_distribution             = simplib::lookup('simp_options::puppet::server_distribution', { 'default_value' => 'PC1' } ),
-  Pupmod::CaTTL                  $ca_ttl                          = '10y',
-  Boolean                        $daemonize                       = true,
-  Boolean                        $enable_ca                       = true,
-  Boolean                        $enable_master                   = true,
-  Stdlib::AbsolutePath           $environmentpath                 = $::pupmod::params::puppet_config['environmentpath'],
-  Boolean                        $freeze_main                     = false,
-  Simplib::Port                  $masterport                      = 8140,
-  Stdlib::AbsolutePath           $puppet_confdir                  = $::pupmod::params::puppet_config['confdir'],
-  Stdlib::AbsolutePath           $confdir                         = $::pupmod::params::master_config['confdir'],
-  Stdlib::AbsolutePath           $codedir                         = $::pupmod::params::master_config['codedir'],
-  Stdlib::AbsolutePath           $vardir                          = $::pupmod::params::master_config['vardir'],
-  Stdlib::AbsolutePath           $rundir                          = $::pupmod::params::master_config['rundir'],
-  Stdlib::AbsolutePath           $logdir                          = $::pupmod::params::master_config['logdir'],
-  Stdlib::AbsolutePath           $ssldir                          = $::pupmod::params::puppet_config['ssldir'],
-  Boolean                        $use_legacy_auth_conf            = true,
-  Boolean                        $firewall                        = simplib::lookup('simp_options::firewall', { 'default_value' => false }),
-  Array[Simplib::Host]           $ca_status_whitelist             = [$facts['fqdn']],
-  Optional[Stdlib::AbsolutePath] $ruby_load_path                  = undef,
-  Integer                        $max_active_instances            = ($facts['processors']['count'] + 2),
-  Array[String]                  $ssl_protocols                   = ['TLSv1', 'TLSv1.1', 'TLSv1.2'],
-  Optional[Array]                $ssl_cipher_suites               = undef,
-  Boolean                        $enable_profiler                 = false,
-  Array[Simplib::Hostname]       $admin_api_whitelist             = [$facts['fqdn']],
-  String                         $admin_api_mountpoint            = '/puppet-admin-api',
-  Boolean                        $log_to_file                     = false,
-  Boolean                        $syslog                          = simplib::lookup('simp_options::syslog', { 'default_value' => false }),
-  String                         $syslog_facility                 = 'LOCAL6',
-  String                         $syslog_message_format           = '%logger[%thread]: %msg',
-  Pupmod::LogLevel               $log_level                       = 'WARN',
-  String                         $package_ensure                  = 'latest',
-  Boolean                        $mock                            = false,
-  Boolean                        $enable_simp_master_auth         = true,
-  Stdlib::AbsolutePath           $auth_conf_path                  = '/etc/puppetlabs/puppetserver/conf.d/auth.conf',
-  Boolean                        $auth_pki_cacerts_all            = true,
-  Boolean                        $auth_pki_mcollective_all        = true,
-  Boolean                        $auth_site_files_cacerts_all     = true,
-  Boolean                        $auth_site_files_mcollective_all = true,
-  Boolean                        $auth_keydist_from_host          = true,
-  Boolean                        $auth_pki_keytabs_from_host      = true,
-  Boolean                        $auth_krb5_keytabs_from_host     = true,
-
+  Simplib::IP                    $bind_address          = '0.0.0.0',
+  Simplib::IP                    $ca_bind_address       = '0.0.0.0',
+  Boolean                        $auditd                = simplib::lookup('simp_options::auditd', { 'default_value' => false }),
+  Simplib::Port                  $ca_port               = simplib::lookup('simp_options::puppet::ca_port', { 'default_value' => 8141 }),
+  Simplib::NetList               $trusted_nets          = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1','::1'] }),
+  String                         $server_distribution   = simplib::lookup('simp_options::puppet::server_distribution', { 'default_value' => 'PC1' } ),
+  Pupmod::CaTTL                  $ca_ttl                = '10y',
+  Boolean                        $daemonize             = true,
+  Boolean                        $enable_ca             = true,
+  Boolean                        $enable_master         = true,
+  Stdlib::AbsolutePath           $environmentpath       = $::pupmod::params::puppet_config['environmentpath'],
+  Boolean                        $freeze_main           = false,
+  Simplib::Port                  $masterport            = 8140,
+  Stdlib::AbsolutePath           $puppet_confdir        = $::pupmod::params::puppet_config['confdir'],
+  Stdlib::AbsolutePath           $confdir               = $::pupmod::params::master_config['confdir'],
+  Stdlib::AbsolutePath           $codedir               = $::pupmod::params::master_config['codedir'],
+  Stdlib::AbsolutePath           $vardir                = $::pupmod::params::master_config['vardir'],
+  Stdlib::AbsolutePath           $rundir                = $::pupmod::params::master_config['rundir'],
+  Stdlib::AbsolutePath           $logdir                = $::pupmod::params::master_config['logdir'],
+  Stdlib::AbsolutePath           $ssldir                = $::pupmod::params::puppet_config['ssldir'],
+  Boolean                        $use_legacy_auth_conf  = true,
+  Boolean                        $firewall              = simplib::lookup('simp_options::firewall', { 'default_value' => false }),
+  Array[Simplib::Host]           $ca_status_whitelist   = [$facts['fqdn']],
+  Optional[Stdlib::AbsolutePath] $ruby_load_path        = undef,
+  Integer                        $max_active_instances  = ($facts['processors']['count'] + 2),
+  Array[String]                  $ssl_protocols         = ['TLSv1', 'TLSv1.1', 'TLSv1.2'],
+  Optional[Array]                $ssl_cipher_suites     = undef,
+  Boolean                        $enable_profiler       = false,
+  Array[Simplib::Hostname]       $admin_api_whitelist   = [$facts['fqdn']],
+  String                         $admin_api_mountpoint  = '/puppet-admin-api',
+  Boolean                        $log_to_file           = false,
+  Boolean                        $syslog                = simplib::lookup('simp_options::syslog', { 'default_value' => false }),
+  String                         $syslog_facility       = 'LOCAL6',
+  String                         $syslog_message_format = '%logger[%thread]: %msg',
+  Pupmod::LogLevel               $log_level             = 'WARN',
+  String                         $package_ensure        = 'latest',
+  Boolean                        $mock                  = false
 ) inherits ::pupmod::params {
   if ($mock == false) {
     $service = 'puppetserver'
@@ -371,10 +321,6 @@ class pupmod::master (
       value   => false,
       #value   => $freeze_main,
       notify  => Service[$service]
-    }
-
-    if $enable_simp_master_auth {
-      include ::pupmod::master::simp_auth
     }
 
     if $auditd {

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -120,7 +120,7 @@ class pupmod::master (
   Stdlib::AbsolutePath           $rundir                = $::pupmod::params::master_config['rundir'],
   Stdlib::AbsolutePath           $logdir                = $::pupmod::params::master_config['logdir'],
   Stdlib::AbsolutePath           $ssldir                = $::pupmod::params::puppet_config['ssldir'],
-  Boolean                        $use_legacy_auth_conf  = true,
+  Boolean                        $use_legacy_auth_conf  = false,
   Boolean                        $firewall              = simplib::lookup('simp_options::firewall', { 'default_value' => false }),
   Array[Simplib::Host]           $ca_status_whitelist   = [$facts['fqdn']],
   Optional[Stdlib::AbsolutePath] $ruby_load_path        = undef,

--- a/manifests/master/simp_auth.pp
+++ b/manifests/master/simp_auth.pp
@@ -5,51 +5,51 @@
 #   Default: /etc/puppetlabs/puppetserver/conf.d/auth.conf
 #   The location to the puppet master's auth.conf
 #
+# @param legacy_cacerts_all
+#   Type:    Boolean
+#   Default: true
+#   If enabled, allow access to the PKI cacerts from the legacy `pki` module from all hosts
+#
+# @param legacy_mcollective_all
+#   Type:    Boolean
+#   Default: true
+#   If enabled, allow access to the mcollective cacerts from the legacy `pki` module from all hosts
+#
+# @param legacy_pki_keytabs_from_host
+#   Type:    Boolean
+#   Default: true
+#   If enabled, allow access to each host's own kerberos keytabs from the legacy location
+#
 # @param pki_cacerts_all
 #   Type:    Boolean
 #   Default: true
-#   If enabled, allow PKI cacerts files from SIMP PKI module from all hosts
+#   If enabled, allow access to the cacerts from the `pki_files` module from all hosts
 #
 # @param pki_mcollective_all
 #   Type:    Boolean
 #   Default: true
-#   If enabled, allow SIMP site_files cacerts access from all hosts
-#
-# @param site_files_cacerts_all
-#   Type:    Boolean
-#   Default: true
-#   If enabled, allow MCO files from SIMP PKI module access from all hosts
-#
-# @param site_files_mcollective_all
-#   Type:    Boolean
-#   Default: true
-#   If enabled, allow SIMP site_files PKI mcollective access from all hosts
+#   If enabled, allow access to the mcollective PKI from the `pki_files` module from all hosts
 #
 # @param keydist_from_host
 #   Type:    Boolean
 #   Default: true
-#   If enabled, allow SIMP PKI keydist module access from specific host
-#
-# @param pki_keytabs_from_host
-#   Type:    Boolean
-#   Default: true
-#   If enabled, allow SIMP site_files PKI keytabs access from specific host
+#   If enabled, allow access to each host's own certs from the `pki_files` module
 #
 # @param krb5_keytabs_from_host
 #   Type:    Boolean
 #   Default: true
-#   If enabled, allow SIMP site_files krb5 keytabs access from specific host
+#   If enabled, allow access to each host's own kerberos keytabs from the `pki_files` module
 #
 class pupmod::master::simp_auth (
-  Simplib::ServerDistribution $server_distribution        = simplib::lookup('simp_options::puppet::server_distribution', { 'default_value' => 'PC1' } ),
-  Stdlib::AbsolutePath        $auth_conf_path             = '/etc/puppetlabs/puppetserver/conf.d/auth.conf',
-  Boolean                     $pki_cacerts_all            = true,
-  Boolean                     $pki_mcollective_all        = true,
-  Boolean                     $site_files_cacerts_all     = true,
-  Boolean                     $site_files_mcollective_all = true,
-  Boolean                     $keydist_from_host          = true,
-  Boolean                     $pki_keytabs_from_host      = true,
-  Boolean                     $krb5_keytabs_from_host     = true,
+  Simplib::ServerDistribution $server_distribution          = simplib::lookup('simp_options::puppet::server_distribution', { 'default_value' => 'PC1' } ),
+  Stdlib::AbsolutePath        $auth_conf_path               = '/etc/puppetlabs/puppetserver/conf.d/auth.conf',
+  Boolean                     $legacy_cacerts_all           = false,
+  Boolean                     $legacy_mcollective_all       = false,
+  Boolean                     $legacy_pki_keytabs_from_host = false,
+  Boolean                     $pki_cacerts_all              = true,
+  Boolean                     $pki_mcollective_all          = true,
+  Boolean                     $keydist_from_host            = true,
+  Boolean                     $krb5_keytabs_from_host       = true,
 ) {
 
   $_master_service = $server_distribution ? {
@@ -57,87 +57,86 @@ class pupmod::master::simp_auth (
     default => 'puppetserver',
   }
 
-  if $pki_cacerts_all {
-    puppet_authorization::rule { 'Allow PKI cacerts files from SIMP PKI module from all hosts':
-      match_request_path   => '^/puppet/v3/file_(metadata|content)/modules/pki/keydist/cacerts',
-      match_request_type   => 'regex',
-      match_request_method => ['get'],
-      allow                => '*',
-      sort_order           => 400,
-      path                 => $auth_conf_path,
-      notify               => Service[$_master_service],
-    }
+  # translates the parameter, which is a boolean, to the ensure parameter for the define
+  $bool2ensure = {
+    true  => 'present',
+    false => 'absent'
   }
 
-  if $site_files_cacerts_all {
-    puppet_authorization::rule { 'Allow SIMP site_files cacerts access from all hosts':
-      match_request_path   => '^/puppet/v3/file_(metadata|content)/site_files/pki_files/files/keydist/cacerts',
-      match_request_type   => 'regex',
-      match_request_method => ['get'],
-      allow                => '*',
-      sort_order           => 410,
-      path                 => $auth_conf_path,
-      notify               => Service[$_master_service],
-    }
+  puppet_authorization::rule { 'Allow access to the PKI cacerts from the legacy pki module from all hosts':
+    ensure               => $bool2ensure[$legacy_cacerts_all],
+    match_request_path   => '^/puppet/v3/file_(metadata|content)/modules/pki/keydist/cacerts',
+    match_request_type   => 'regex',
+    match_request_method => ['get'],
+    allow                => '*',
+    sort_order           => 400,
+    path                 => $auth_conf_path,
+    notify               => Service[$_master_service],
   }
 
-  if $pki_mcollective_all {
-    puppet_authorization::rule { 'Allow MCO files from SIMP PKI module access from all hosts':
-      match_request_path   => '^/puppet/v3/file_(metadata|content)/modules/pki/keydist/mcollective',
-      match_request_type   => 'regex',
-      match_request_method => ['get'],
-      allow                => '*',
-      sort_order           => 420,
-      path                 => $auth_conf_path,
-      notify               => Service[$_master_service],
-    }
+  puppet_authorization::rule { 'Allow access to the mcollective cacerts from the legacy pki module from all hosts':
+    ensure               => $bool2ensure[$legacy_mcollective_all],
+    match_request_path   => '^/puppet/v3/file_(metadata|content)/modules/pki/keydist/mcollective',
+    match_request_type   => 'regex',
+    match_request_method => ['get'],
+    allow                => '*',
+    sort_order           => 420,
+    path                 => $auth_conf_path,
+    notify               => Service[$_master_service],
   }
 
-  if $site_files_mcollective_all {
-    puppet_authorization::rule { 'Allow SIMP site_files PKI mcollective access from all hosts':
-      match_request_path   => '^/puppet/v3/file_(metadata|content)/site_files/pki_files/files/keydist/mcollective',
-      match_request_type   => 'regex',
-      match_request_method => ['get'],
-      allow                => '*',
-      sort_order           => 430,
-      path                 => $auth_conf_path,
-      notify               => Service[$_master_service],
-    }
+  puppet_authorization::rule { 'Allow access to each hosts own kerberos keytabs from the legacy location':
+    ensure               => $bool2ensure[$legacy_pki_keytabs_from_host],
+    match_request_path   => '^/puppet/v3/file_(metadata|content)/site_files/pki_files/files/keytabs/([^/]+)',
+    match_request_type   => 'regex',
+    match_request_method => ['get'],
+    allow                => '$2',
+    sort_order           => 450,
+    path                 => $auth_conf_path,
+    notify               => Service[$_master_service],
   }
 
-  if $keydist_from_host {
-    puppet_authorization::rule { 'Allow SIMP PKI keydist module access from specific host':
-      match_request_path   => '^/puppet/v3/file_(metadata|content)/modules/pki/keydist/([^/]+)',
-      match_request_type   => 'regex',
-      match_request_method => ['get'],
-      allow                => '$2',
-      sort_order           => 440,
-      path                 => $auth_conf_path,
-      notify               => Service[$_master_service],
-    }
+  puppet_authorization::rule { 'Allow access to the cacerts from the pki_files module from all hosts':
+    ensure               => $bool2ensure[$pki_cacerts_all],
+    match_request_path   => '^/puppet/v3/file_(metadata|content)/site_files/pki_files/files/keydist/cacerts',
+    match_request_type   => 'regex',
+    match_request_method => ['get'],
+    allow                => '*',
+    sort_order           => 410,
+    path                 => $auth_conf_path,
+    notify               => Service[$_master_service],
   }
 
-  if $pki_keytabs_from_host {
-    puppet_authorization::rule { 'Allow SIMP site_files PKI keytabs access from specific host':
-      match_request_path   => '^/puppet/v3/file_(metadata|content)/site_files/pki_files/files/keytabs/([^/]+)',
-      match_request_type   => 'regex',
-      match_request_method => ['get'],
-      allow                => '$2',
-      sort_order           => 450,
-      path                 => $auth_conf_path,
-      notify               => Service[$_master_service],
-    }
+  puppet_authorization::rule { 'Allow access to the mcollective PKI from the pki_files module from all hosts':
+    ensure               => $bool2ensure[$pki_mcollective_all],
+    match_request_path   => '^/puppet/v3/file_(metadata|content)/site_files/pki_files/files/keydist/mcollective',
+    match_request_type   => 'regex',
+    match_request_method => ['get'],
+    allow                => '*',
+    sort_order           => 430,
+    path                 => $auth_conf_path,
+    notify               => Service[$_master_service],
   }
 
-  if $krb5_keytabs_from_host {
-    puppet_authorization::rule { 'Allow SIMP site_files krb5 keytabs access from specific host':
-      match_request_path   => '^/puppet/v3/file_(metadata|content)/site_files/krb5_files/files/keytabs/([^/]+)',
-      match_request_type   => 'regex',
-      match_request_method => ['get'],
-      allow                => '$2',
-      sort_order           => 460,
-      path                 => $auth_conf_path,
-      notify               => Service[$_master_service],
-    }
+  puppet_authorization::rule { 'Allow access to each hosts own certs from the pki_files module':
+    ensure               => $bool2ensure[$keydist_from_host],
+    match_request_path   => '^/puppet/v3/file_(metadata|content)/modules/pki_files/keydist/([^/]+)',
+    match_request_type   => 'regex',
+    match_request_method => ['get'],
+    allow                => '$2',
+    sort_order           => 440,
+    path                 => $auth_conf_path,
+    notify               => Service[$_master_service],
+  }
+
+  puppet_authorization::rule { 'Allow access to each hosts own kerberos keytabs from the pki_files module':
+    ensure               => $bool2ensure[$krb5_keytabs_from_host],
+    match_request_path   => '^/puppet/v3/file_(metadata|content)/site_files/krb5_files/files/keytabs/([^/]+)',
+    match_request_type   => 'regex',
+    match_request_method => ['get'],
+    allow                => '$2',
+    sort_order           => 460,
+    path                 => $auth_conf_path,
+    notify               => Service[$_master_service],
   }
 }

--- a/manifests/master/simp_auth.pp
+++ b/manifests/master/simp_auth.pp
@@ -144,6 +144,7 @@ class pupmod::master::simp_auth (
   # as root:root. The puppetserver attempts to read this file because it exists,
   # and can't because of the permissions (puppetserver runs as puppet:puppet).
   file { '/etc/puppetlabs/puppet/auth.conf':
-    ensure => absent
+    ensure => absent,
+    notify => Service[$_master_service]
   }
 }

--- a/manifests/master/simp_auth.pp
+++ b/manifests/master/simp_auth.pp
@@ -139,4 +139,11 @@ class pupmod::master::simp_auth (
     path                 => $auth_conf_path,
     notify               => Service[$_master_service],
   }
+
+  # The puppet-agent package drops off this file for some reason, and it comes
+  # as root:root. The puppetserver attempts to read this file because it exists,
+  # and can't because of the permissions (puppetserver runs as puppet:puppet).
+  file { '/etc/puppetlabs/puppet/auth.conf':
+    ensure => absent
+  }
 }

--- a/manifests/master/simp_auth.pp
+++ b/manifests/master/simp_auth.pp
@@ -87,7 +87,7 @@ class pupmod::master::simp_auth (
 
   puppet_authorization::rule { 'Allow access to each hosts own kerberos keytabs from the legacy location':
     ensure               => $bool2ensure[$legacy_pki_keytabs_from_host],
-    match_request_path   => '^/puppet/v3/file_(metadata|content)/site_files/pki_files/files/keytabs/([^/]+)',
+    match_request_path   => '^/puppet/v3/file_(metadata|content)/pki_files/keytabs/([^/]+)',
     match_request_type   => 'regex',
     match_request_method => ['get'],
     allow                => '$2',
@@ -98,7 +98,7 @@ class pupmod::master::simp_auth (
 
   puppet_authorization::rule { 'Allow access to the cacerts from the pki_files module from all hosts':
     ensure               => $bool2ensure[$pki_cacerts_all],
-    match_request_path   => '^/puppet/v3/file_(metadata|content)/site_files/pki_files/files/keydist/cacerts',
+    match_request_path   => '^/puppet/v3/file_(metadata|content)/pki_files/keydist/cacerts',
     match_request_type   => 'regex',
     match_request_method => ['get'],
     allow                => '*',
@@ -109,7 +109,7 @@ class pupmod::master::simp_auth (
 
   puppet_authorization::rule { 'Allow access to the mcollective PKI from the pki_files module from all hosts':
     ensure               => $bool2ensure[$pki_mcollective_all],
-    match_request_path   => '^/puppet/v3/file_(metadata|content)/site_files/pki_files/files/keydist/mcollective',
+    match_request_path   => '^/puppet/v3/file_(metadata|content)/pki_files/keydist/mcollective',
     match_request_type   => 'regex',
     match_request_method => ['get'],
     allow                => '*',
@@ -131,7 +131,7 @@ class pupmod::master::simp_auth (
 
   puppet_authorization::rule { 'Allow access to each hosts own kerberos keytabs from the pki_files module':
     ensure               => $bool2ensure[$krb5_keytabs_from_host],
-    match_request_path   => '^/puppet/v3/file_(metadata|content)/site_files/krb5_files/files/keytabs/([^/]+)',
+    match_request_path   => '^/puppet/v3/file_(metadata|content)/krb5_files/keytabs/([^/]+)',
     match_request_type   => 'regex',
     match_request_method => ['get'],
     allow                => '$2',

--- a/manifests/master/simp_auth.pp
+++ b/manifests/master/simp_auth.pp
@@ -1,20 +1,56 @@
 # Add SIMP-specific entries to PuppetServer's auth.conf
 #
-# NOTE: This is a private class.  The parameters of this class are exposed via the
-# pupmod::master API.
+# @param auth_conf_path
+#   Type:    Stdlib::AbsolutePath
+#   Default: /etc/puppetlabs/puppetserver/conf.d/auth.conf
+#   The location to the puppet master's auth.conf
+#
+# @param pki_cacerts_all
+#   Type:    Boolean
+#   Default: true
+#   If enabled, allow PKI cacerts files from SIMP PKI module from all hosts
+#
+# @param pki_mcollective_all
+#   Type:    Boolean
+#   Default: true
+#   If enabled, allow SIMP site_files cacerts access from all hosts
+#
+# @param site_files_cacerts_all
+#   Type:    Boolean
+#   Default: true
+#   If enabled, allow MCO files from SIMP PKI module access from all hosts
+#
+# @param site_files_mcollective_all
+#   Type:    Boolean
+#   Default: true
+#   If enabled, allow SIMP site_files PKI mcollective access from all hosts
+#
+# @param keydist_from_host
+#   Type:    Boolean
+#   Default: true
+#   If enabled, allow SIMP PKI keydist module access from specific host
+#
+# @param pki_keytabs_from_host
+#   Type:    Boolean
+#   Default: true
+#   If enabled, allow SIMP site_files PKI keytabs access from specific host
+#
+# @param krb5_keytabs_from_host
+#   Type:    Boolean
+#   Default: true
+#   If enabled, allow SIMP site_files krb5 keytabs access from specific host
 #
 class pupmod::master::simp_auth (
-  Simplib::ServerDistribution $server_distribution        = $::pupmod::master::server_distribution,
-  Stdlib::AbsolutePath        $auth_conf_path             = $::pupmod::master::auth_conf_path,
-  Boolean                     $pki_cacerts_all            = $::pupmod::master::auth_pki_cacerts_all,
-  Boolean                     $pki_mcollective_all        = $::pupmod::master::auth_pki_mcollective_all,
-  Boolean                     $site_files_cacerts_all     = $::pupmod::master::auth_site_files_cacerts_all,
-  Boolean                     $site_files_mcollective_all = $::pupmod::master::auth_site_files_mcollective_all,
-  Boolean                     $keydist_from_host          = $::pupmod::master::auth_keydist_from_host,
-  Boolean                     $pki_keytabs_from_host      = $::pupmod::master::auth_pki_keytabs_from_host,
-  Boolean                     $krb5_keytabs_from_host     = $::pupmod::master::auth_krb5_keytabs_from_host,
-) inherits ::pupmod::master {
-  assert_private()
+  Simplib::ServerDistribution $server_distribution        = simplib::lookup('simp_options::puppet::server_distribution', { 'default_value' => 'PC1' } ),
+  Stdlib::AbsolutePath        $auth_conf_path             = '/etc/puppetlabs/puppetserver/conf.d/auth.conf',
+  Boolean                     $pki_cacerts_all            = true,
+  Boolean                     $pki_mcollective_all        = true,
+  Boolean                     $site_files_cacerts_all     = true,
+  Boolean                     $site_files_mcollective_all = true,
+  Boolean                     $keydist_from_host          = true,
+  Boolean                     $pki_keytabs_from_host      = true,
+  Boolean                     $krb5_keytabs_from_host     = true,
+) {
 
   $_master_service = $server_distribution ? {
     'PE'    => 'pe-puppetserver',

--- a/manifests/master/simp_auth.pp
+++ b/manifests/master/simp_auth.pp
@@ -1,0 +1,107 @@
+# Add SIMP-specific entries to PuppetServer's auth.conf
+#
+# NOTE: This is a private class.  The parameters of this class are exposed via the
+# pupmod::master API.
+#
+class pupmod::master::simp_auth (
+  Simplib::ServerDistribution $server_distribution        = $::pupmod::master::server_distribution,
+  Stdlib::AbsolutePath        $auth_conf_path             = $::pupmod::master::auth_conf_path,
+  Boolean                     $pki_cacerts_all            = $::pupmod::master::auth_pki_cacerts_all,
+  Boolean                     $pki_mcollective_all        = $::pupmod::master::auth_pki_mcollective_all,
+  Boolean                     $site_files_cacerts_all     = $::pupmod::master::auth_site_files_cacerts_all,
+  Boolean                     $site_files_mcollective_all = $::pupmod::master::auth_site_files_mcollective_all,
+  Boolean                     $keydist_from_host          = $::pupmod::master::auth_keydist_from_host,
+  Boolean                     $pki_keytabs_from_host      = $::pupmod::master::auth_pki_keytabs_from_host,
+  Boolean                     $krb5_keytabs_from_host     = $::pupmod::master::auth_krb5_keytabs_from_host,
+) inherits ::pupmod::master {
+  assert_private()
+
+  $_master_service = $server_distribution ? {
+    'PE'    => 'pe-puppetserver',
+    default => 'puppetserver',
+  }
+
+  if $pki_cacerts_all {
+    puppet_authorization::rule { 'Allow PKI cacerts files from SIMP PKI module from all hosts':
+      match_request_path   => '^/puppet/v3/file_(metadata|content)/modules/pki/keydist/cacerts',
+      match_request_type   => 'regex',
+      match_request_method => ['get'],
+      allow                => '*',
+      sort_order           => 400,
+      path                 => $auth_conf_path,
+      notify               => Service[$_master_service],
+    }
+  }
+
+  if $site_files_cacerts_all {
+    puppet_authorization::rule { 'Allow SIMP site_files cacerts access from all hosts':
+      match_request_path   => '^/puppet/v3/file_(metadata|content)/site_files/pki_files/files/keydist/cacerts',
+      match_request_type   => 'regex',
+      match_request_method => ['get'],
+      allow                => '*',
+      sort_order           => 410,
+      path                 => $auth_conf_path,
+      notify               => Service[$_master_service],
+    }
+  }
+
+  if $pki_mcollective_all {
+    puppet_authorization::rule { 'Allow MCO files from SIMP PKI module access from all hosts':
+      match_request_path   => '^/puppet/v3/file_(metadata|content)/modules/pki/keydist/mcollective',
+      match_request_type   => 'regex',
+      match_request_method => ['get'],
+      allow                => '*',
+      sort_order           => 420,
+      path                 => $auth_conf_path,
+      notify               => Service[$_master_service],
+    }
+  }
+
+  if $site_files_mcollective_all {
+    puppet_authorization::rule { 'Allow SIMP site_files PKI mcollective access from all hosts':
+      match_request_path   => '^/puppet/v3/file_(metadata|content)/site_files/pki_files/files/keydist/mcollective',
+      match_request_type   => 'regex',
+      match_request_method => ['get'],
+      allow                => '*',
+      sort_order           => 430,
+      path                 => $auth_conf_path,
+      notify               => Service[$_master_service],
+    }
+  }
+
+  if $keydist_from_host {
+    puppet_authorization::rule { 'Allow SIMP PKI keydist module access from specific host':
+      match_request_path   => '^/puppet/v3/file_(metadata|content)/modules/pki/keydist/([^/]+)',
+      match_request_type   => 'regex',
+      match_request_method => ['get'],
+      allow                => '$2',
+      sort_order           => 440,
+      path                 => $auth_conf_path,
+      notify               => Service[$_master_service],
+    }
+  }
+
+  if $pki_keytabs_from_host {
+    puppet_authorization::rule { 'Allow SIMP site_files PKI keytabs access from specific host':
+      match_request_path   => '^/puppet/v3/file_(metadata|content)/site_files/pki_files/files/keytabs/([^/]+)',
+      match_request_type   => 'regex',
+      match_request_method => ['get'],
+      allow                => '$2',
+      sort_order           => 450,
+      path                 => $auth_conf_path,
+      notify               => Service[$_master_service],
+    }
+  }
+
+  if $krb5_keytabs_from_host {
+    puppet_authorization::rule { 'Allow SIMP site_files krb5 keytabs access from specific host':
+      match_request_path   => '^/puppet/v3/file_(metadata|content)/site_files/krb5_files/files/keytabs/([^/]+)',
+      match_request_type   => 'regex',
+      match_request_method => ['get'],
+      allow                => '$2',
+      sort_order           => 460,
+      path                 => $auth_conf_path,
+      notify               => Service[$_master_service],
+    }
+  }
+}

--- a/manifests/pass_two.pp
+++ b/manifests/pass_two.pp
@@ -116,6 +116,9 @@ define pupmod::pass_two (
         service             => 'pe-puppetserver',
         user                => 'pe-puppet',
       }
+      # class { 'pupmod::master::simp_auth':
+      #   server_distribution => 'PE'
+      # }
     }
   }
 

--- a/manifests/pass_two.pp
+++ b/manifests/pass_two.pp
@@ -116,9 +116,9 @@ define pupmod::pass_two (
         service             => 'pe-puppetserver',
         user                => 'pe-puppet',
       }
-      # class { 'pupmod::master::simp_auth':
-      #   server_distribution => 'PE'
-      # }
+    }
+    class { 'pupmod::master::simp_auth':
+      server_distribution => $_server_distribution
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -26,6 +26,10 @@
       "version_requirement": ">= 4.13.0 < 5.0.0"
     },
     {
+      "name": "puppetlabs/puppet_authorization",
+      "version_requirement": ">= 0.2.0"
+    },
+    {
       "name": "simp/iptables",
       "version_requirement": ">= 6.0.0 < 7.0.0"
     },

--- a/metadata.json
+++ b/metadata.json
@@ -27,7 +27,7 @@
     },
     {
       "name": "puppetlabs/puppet_authorization",
-      "version_requirement": ">= 0.2.0"
+      "version_requirement": ">= 0.2.0 < 1.0.0"
     },
     {
       "name": "simp/iptables",

--- a/spec/classes/master/base_spec.rb
+++ b/spec/classes/master/base_spec.rb
@@ -1,4 +1,3 @@
-#
 require 'spec_helper'
 
 describe 'pupmod::master::base' do

--- a/spec/classes/master/simp_auth_spec.rb
+++ b/spec/classes/master/simp_auth_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+
+describe 'pupmod::master::simp_auth' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) do
+        os_facts
+      end
+
+      context 'with default parameters' do
+        it { is_expected.to create_class('pupmod::master::simp_auth') }
+        it { is_expected.to create_puppet_authorization__rule('Allow PKI cacerts files from SIMP PKI module from all hosts').with({
+          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/pki/keydist/cacerts',
+          'match_request_type'   => 'regex',
+          'match_request_method' => ['get'],
+          'allow'                => '*',
+          'sort_order'           => 400,
+        }) }
+        it { is_expected.to create_puppet_authorization__rule('Allow SIMP site_files cacerts access from all hosts').with({
+          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/site_files/pki_files/files/keydist/cacerts',
+          'match_request_type'   => 'regex',
+          'match_request_method' => ['get'],
+          'allow'                => '*',
+          'sort_order'           => 410,
+        }) }
+        it { is_expected.to create_puppet_authorization__rule('Allow MCO files from SIMP PKI module access from all hosts').with({
+          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/pki/keydist/mcollective',
+          'match_request_type'   => 'regex',
+          'match_request_method' => ['get'],
+          'allow'                => '*',
+          'sort_order'           => 420,
+        }) }
+        it { is_expected.to create_puppet_authorization__rule('Allow SIMP site_files PKI mcollective access from all hosts').with({
+          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/site_files/pki_files/files/keydist/mcollective',
+          'match_request_type'   => 'regex',
+          'match_request_method' => ['get'],
+          'allow'                => '*',
+          'sort_order'           => 430,
+        }) }
+        it { is_expected.to create_puppet_authorization__rule('Allow SIMP PKI keydist module access from specific host').with({
+          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/pki/keydist/([^/]+)',
+          'match_request_type'   => 'regex',
+          'match_request_method' => ['get'],
+          'allow'                => '$2',
+          'sort_order'           => 440,
+        }) }
+        it { is_expected.to create_puppet_authorization__rule('Allow SIMP site_files PKI keytabs access from specific host').with({
+          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/site_files/pki_files/files/keytabs/([^/]+)',
+          'match_request_type'   => 'regex',
+          'match_request_method' => ['get'],
+          'allow'                => '$2',
+          'sort_order'           => 450,
+        }) }
+        it { is_expected.to create_puppet_authorization__rule('Allow SIMP site_files krb5 keytabs access from specific host').with({
+          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/site_files/krb5_files/files/keytabs/([^/]+)',
+          'match_request_type'   => 'regex',
+          'match_request_method' => ['get'],
+          'allow'                => '$2',
+          'sort_order'           => 460,
+        }) }
+      end
+
+      context 'not managing one of the rules' do
+        let(:params) {{ :site_files_mcollective_all => false }}
+        it { is_expected.to create_puppet_authorization__rule('Allow PKI cacerts files from SIMP PKI module from all hosts') }
+        it { is_expected.to create_puppet_authorization__rule('Allow SIMP site_files cacerts access from all hosts') }
+        it { is_expected.to create_puppet_authorization__rule('Allow MCO files from SIMP PKI module access from all hosts') }
+        it { is_expected.not_to create_puppet_authorization__rule('Allow SIMP site_files PKI mcollective access from all hosts') }
+        it { is_expected.to create_puppet_authorization__rule('Allow SIMP PKI keydist module access from specific host') }
+        it { is_expected.to create_puppet_authorization__rule('Allow SIMP site_files PKI keytabs access from specific host') }
+        it { is_expected.to create_puppet_authorization__rule('Allow SIMP site_files krb5 keytabs access from specific host') }
+      end
+
+      context 'on PE' do
+        let(:params) {{ :server_distribution => 'PE' }}
+        it { is_expected.to create_puppet_authorization__rule('Allow SIMP site_files krb5 keytabs access from specific host').with({
+          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/site_files/krb5_files/files/keytabs/([^/]+)',
+          'match_request_type'   => 'regex',
+          'match_request_method' => ['get'],
+          'allow'                => '$2',
+          'sort_order'           => 460,
+          'notify'               => 'Service[pe-puppetserver]'
+        }) }
+      end
+
+    end
+  end
+end

--- a/spec/classes/master/simp_auth_spec.rb
+++ b/spec/classes/master/simp_auth_spec.rb
@@ -9,49 +9,56 @@ describe 'pupmod::master::simp_auth' do
 
       context 'with default parameters' do
         it { is_expected.to create_class('pupmod::master::simp_auth') }
-        it { is_expected.to create_puppet_authorization__rule('Allow PKI cacerts files from SIMP PKI module from all hosts').with({
+        it { is_expected.to create_puppet_authorization__rule('Allow access to the PKI cacerts from the legacy pki module from all hosts').with({
+          'ensure'               => 'absent',
           'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/pki/keydist/cacerts',
           'match_request_type'   => 'regex',
           'match_request_method' => ['get'],
           'allow'                => '*',
           'sort_order'           => 400,
         }) }
-        it { is_expected.to create_puppet_authorization__rule('Allow SIMP site_files cacerts access from all hosts').with({
+        it { is_expected.to create_puppet_authorization__rule('Allow access to the cacerts from the pki_files module from all hosts').with({
+          'ensure'               => 'present',
           'match_request_path'   => '^/puppet/v3/file_(metadata|content)/site_files/pki_files/files/keydist/cacerts',
           'match_request_type'   => 'regex',
           'match_request_method' => ['get'],
           'allow'                => '*',
           'sort_order'           => 410,
         }) }
-        it { is_expected.to create_puppet_authorization__rule('Allow MCO files from SIMP PKI module access from all hosts').with({
+        it { is_expected.to create_puppet_authorization__rule('Allow access to the mcollective cacerts from the legacy pki module from all hosts').with({
+          'ensure'               => 'absent',
           'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/pki/keydist/mcollective',
           'match_request_type'   => 'regex',
           'match_request_method' => ['get'],
           'allow'                => '*',
           'sort_order'           => 420,
         }) }
-        it { is_expected.to create_puppet_authorization__rule('Allow SIMP site_files PKI mcollective access from all hosts').with({
+        it { is_expected.to create_puppet_authorization__rule('Allow access to the mcollective PKI from the pki_files module from all hosts').with({
+          'ensure'               => 'present',
           'match_request_path'   => '^/puppet/v3/file_(metadata|content)/site_files/pki_files/files/keydist/mcollective',
           'match_request_type'   => 'regex',
           'match_request_method' => ['get'],
           'allow'                => '*',
           'sort_order'           => 430,
         }) }
-        it { is_expected.to create_puppet_authorization__rule('Allow SIMP PKI keydist module access from specific host').with({
-          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/pki/keydist/([^/]+)',
+        it { is_expected.to create_puppet_authorization__rule('Allow access to each hosts own certs from the pki_files module').with({
+          'ensure'               => 'present',
+          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/pki_files/keydist/([^/]+)',
           'match_request_type'   => 'regex',
           'match_request_method' => ['get'],
           'allow'                => '$2',
           'sort_order'           => 440,
         }) }
-        it { is_expected.to create_puppet_authorization__rule('Allow SIMP site_files PKI keytabs access from specific host').with({
+        it { is_expected.to create_puppet_authorization__rule('Allow access to each hosts own kerberos keytabs from the legacy location').with({
+          'ensure'               => 'absent',
           'match_request_path'   => '^/puppet/v3/file_(metadata|content)/site_files/pki_files/files/keytabs/([^/]+)',
           'match_request_type'   => 'regex',
           'match_request_method' => ['get'],
           'allow'                => '$2',
           'sort_order'           => 450,
         }) }
-        it { is_expected.to create_puppet_authorization__rule('Allow SIMP site_files krb5 keytabs access from specific host').with({
+        it { is_expected.to create_puppet_authorization__rule('Allow access to each hosts own kerberos keytabs from the pki_files module').with({
+          'ensure'               => 'present',
           'match_request_path'   => '^/puppet/v3/file_(metadata|content)/site_files/krb5_files/files/keytabs/([^/]+)',
           'match_request_type'   => 'regex',
           'match_request_method' => ['get'],
@@ -60,20 +67,10 @@ describe 'pupmod::master::simp_auth' do
         }) }
       end
 
-      context 'not managing one of the rules' do
-        let(:params) {{ :site_files_mcollective_all => false }}
-        it { is_expected.to create_puppet_authorization__rule('Allow PKI cacerts files from SIMP PKI module from all hosts') }
-        it { is_expected.to create_puppet_authorization__rule('Allow SIMP site_files cacerts access from all hosts') }
-        it { is_expected.to create_puppet_authorization__rule('Allow MCO files from SIMP PKI module access from all hosts') }
-        it { is_expected.not_to create_puppet_authorization__rule('Allow SIMP site_files PKI mcollective access from all hosts') }
-        it { is_expected.to create_puppet_authorization__rule('Allow SIMP PKI keydist module access from specific host') }
-        it { is_expected.to create_puppet_authorization__rule('Allow SIMP site_files PKI keytabs access from specific host') }
-        it { is_expected.to create_puppet_authorization__rule('Allow SIMP site_files krb5 keytabs access from specific host') }
-      end
-
       context 'on PE' do
         let(:params) {{ :server_distribution => 'PE' }}
-        it { is_expected.to create_puppet_authorization__rule('Allow SIMP site_files krb5 keytabs access from specific host').with({
+        it { is_expected.to create_puppet_authorization__rule('Allow access to each hosts own kerberos keytabs from the pki_files module').with({
+          'ensure'               => 'present',
           'match_request_path'   => '^/puppet/v3/file_(metadata|content)/site_files/krb5_files/files/keytabs/([^/]+)',
           'match_request_type'   => 'regex',
           'match_request_method' => ['get'],

--- a/spec/classes/master/simp_auth_spec.rb
+++ b/spec/classes/master/simp_auth_spec.rb
@@ -19,7 +19,7 @@ describe 'pupmod::master::simp_auth' do
         }) }
         it { is_expected.to create_puppet_authorization__rule('Allow access to the cacerts from the pki_files module from all hosts').with({
           'ensure'               => 'present',
-          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/site_files/pki_files/files/keydist/cacerts',
+          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/pki_files/keydist/cacerts',
           'match_request_type'   => 'regex',
           'match_request_method' => ['get'],
           'allow'                => '*',
@@ -35,7 +35,7 @@ describe 'pupmod::master::simp_auth' do
         }) }
         it { is_expected.to create_puppet_authorization__rule('Allow access to the mcollective PKI from the pki_files module from all hosts').with({
           'ensure'               => 'present',
-          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/site_files/pki_files/files/keydist/mcollective',
+          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/pki_files/keydist/mcollective',
           'match_request_type'   => 'regex',
           'match_request_method' => ['get'],
           'allow'                => '*',
@@ -51,7 +51,7 @@ describe 'pupmod::master::simp_auth' do
         }) }
         it { is_expected.to create_puppet_authorization__rule('Allow access to each hosts own kerberos keytabs from the legacy location').with({
           'ensure'               => 'absent',
-          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/site_files/pki_files/files/keytabs/([^/]+)',
+          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/pki_files/keytabs/([^/]+)',
           'match_request_type'   => 'regex',
           'match_request_method' => ['get'],
           'allow'                => '$2',
@@ -59,7 +59,7 @@ describe 'pupmod::master::simp_auth' do
         }) }
         it { is_expected.to create_puppet_authorization__rule('Allow access to each hosts own kerberos keytabs from the pki_files module').with({
           'ensure'               => 'present',
-          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/site_files/krb5_files/files/keytabs/([^/]+)',
+          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/krb5_files/keytabs/([^/]+)',
           'match_request_type'   => 'regex',
           'match_request_method' => ['get'],
           'allow'                => '$2',
@@ -72,7 +72,7 @@ describe 'pupmod::master::simp_auth' do
         let(:params) {{ :server_distribution => 'PE' }}
         it { is_expected.to create_puppet_authorization__rule('Allow access to each hosts own kerberos keytabs from the pki_files module').with({
           'ensure'               => 'present',
-          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/site_files/krb5_files/files/keytabs/([^/]+)',
+          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/krb5_files/keytabs/([^/]+)',
           'match_request_type'   => 'regex',
           'match_request_method' => ['get'],
           'allow'                => '$2',

--- a/spec/classes/master/simp_auth_spec.rb
+++ b/spec/classes/master/simp_auth_spec.rb
@@ -65,6 +65,7 @@ describe 'pupmod::master::simp_auth' do
           'allow'                => '$2',
           'sort_order'           => 460,
         }) }
+        it { is_expected.to create_file('/etc/puppetlabs/puppet/auth.conf').with_ensure('absent') }
       end
 
       context 'on PE' do

--- a/spec/classes/master/sysconfig_spec.rb
+++ b/spec/classes/master/sysconfig_spec.rb
@@ -1,4 +1,3 @@
-#
 require 'spec_helper'
 
 describe 'pupmod::master::sysconfig' do

--- a/spec/classes/master_spec.rb
+++ b/spec/classes/master_spec.rb
@@ -176,7 +176,7 @@ jruby-puppet: {
     # (optional) Authorize access to Puppet master endpoints via rules specified
     # in the legacy Puppet auth.conf file (if true or not specified) or via rules
     # specified in the Puppet Server HOCON-formatted auth.conf (if false).
-    use-legacy-auth-conf: true
+    use-legacy-auth-conf: false
 }
 
 # settings related to HTTP client requests made by Puppet Server
@@ -514,7 +514,7 @@ jruby-puppet: {
     # (optional) Authorize access to Puppet master endpoints via rules specified
     # in the legacy Puppet auth.conf file (if true or not specified) or via rules
     # specified in the Puppet Server HOCON-formatted auth.conf (if false).
-    use-legacy-auth-conf: true
+    use-legacy-auth-conf: false
 }
 
 # settings related to HTTP client requests made by Puppet Server


### PR DESCRIPTION
…e to modify puppetserver's auth.conf

* Added a simp_auth manifest underneath master for managing simp-specific entries of auth.conf.
* Include from top level pupmod::master manifest as that should drive all puppet master settings.

SIMP-3049 #comment This should complete the simp-pupmod portion of this ticket