### PR TITLE
(SIMP-3285) - Ensure legacy auth.conf is backed up

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Jun 05 2017 Nick Markowski <nmarkowski@keywcorp.com> - 7.3.2-0
+- Ensure legacy auth.conf is backed up before removing it. This is a
+  follow up to SIMP-3049 based on feedback to SIMP-3196.
+
 * Mon May 22 2017 Kendall Moore <kendall.moore@onyxpoint.com> 7.3.2-0
 - Added manifest to manage simp-specific puppet master auth requirements
 - Disabled puppetserver setting to enable legacy auth.conf by default

--- a/manifests/master/simp_auth.pp
+++ b/manifests/master/simp_auth.pp
@@ -143,8 +143,10 @@ class pupmod::master::simp_auth (
   # The puppet-agent package drops off this file for some reason, and it comes
   # as root:root. The puppetserver attempts to read this file because it exists,
   # and can't because of the permissions (puppetserver runs as puppet:puppet).
+  # Back it up to preserve custom content on upgrade, and blow it away.
   file { '/etc/puppetlabs/puppet/auth.conf':
     ensure => absent,
+    backup => true,
     notify => Service[$_master_service]
   }
 }


### PR DESCRIPTION
This is a follow up to SIMP-3049 based on feedback to SIMP-3196.

SIMP-3285 #close