### PR TITLE
(SIMP-3265) Remove CRL pull cron job

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 * Wed Jun 14 2017 Nick Miller <nick.miller@onyxpoint.com> - 7.3.2-0
-- Removed Puppet CRL download, the puppet agent now checks for the expiraton of
+- Removed Puppet CRL download, the puppet agent now checks for the expiration of
   the cert automatically
 
 * Mon Jun 05 2017 Nick Markowski <nmarkowski@keywcorp.com> - 7.3.2-0

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Wed Jun 14 2017 Nick Miller <nick.miller@onyxpoint.com> - 7.3.3-0
+* Wed Jun 14 2017 Nick Miller <nick.miller@onyxpoint.com> - 7.3.2-0
 - Removed Puppet CRL download, the puppet agent now checks for the expiraton of
   the cert automatically
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Jun 14 2017 Nick Miller <nick.miller@onyxpoint.com> - 7.3.3-0
+- Removed Puppet CRL download, the puppet agent now checks for the expiraton of
+  the cert automatically
+
 * Mon Jun 05 2017 Nick Markowski <nmarkowski@keywcorp.com> - 7.3.2-0
 - Ensure legacy auth.conf is backed up before removing it. This is a
   follow up to SIMP-3049 based on feedback to SIMP-3196.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,12 +21,6 @@
 #   The server distribution used. This changes the configuration based on whether
 #   we are using PC1 or PE
 #
-# @param ca_crl_pull_interval
-#   How many times per day to pull the CRL down from the CA via cron.
-#
-#   This uses ip_to_cron to randomize the pull interval so that the CA doesn't
-#   get swarmed.
-#
 # @param certname
 #   The puppet environment name of the system.
 #
@@ -138,7 +132,6 @@ class pupmod (
   Simplib::Port                          $ca_port              = simplib::lookup('simp_options::puppet::ca_port', { 'default_value' => 8141 }),
   Simplib::Host                          $puppet_server        = simplib::lookup('simp_options::puppet::server', { 'default_value' => "puppet.${facts['domain']}" }),
   Simplib::ServerDistribution            $server_distribution  = simplib::lookup('simp_options::puppet::server_distribution', { 'default_value' => 'PC1' } ),
-  Integer                                $ca_crl_pull_interval = 2,
   Simplib::Host                          $certname             = $facts['fqdn'],
   String                                 $classfile            = '$vardir/classes.txt',
   Stdlib::AbsolutePath                   $confdir              = $::pupmod::params::puppet_config['confdir'],
@@ -179,20 +172,11 @@ class pupmod (
       include '::haveged'
     }
 
-    $l_crl_pull_minute = ip_to_cron(1)
-    $l_crl_pull_hour = ip_to_cron($ca_crl_pull_interval,24)
-
     if $enable_puppet_master {
       include 'pupmod::master'
     }
     package { 'puppet-agent': ensure => $package_ensure }
 
-    cron { 'puppet_crl_pull':
-      command => template('pupmod/commands/crl_download.erb'),
-      user    => 'root',
-      minute  => ip_to_cron(1),
-      hour    => ip_to_cron($ca_crl_pull_interval,24)
-    }
     if $daemonize {
       cron { 'puppetagent': ensure => 'absent' }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,12 +22,7 @@
 #   we are using PC1 or PE
 #
 # @param ca_crl_pull_interval
-#   How many times per day to pull the CRL down from the CA via cron.
-#
-#   This uses ip_to_cron to randomize the pull interval so that the CA doesn't
-#   get swarmed.
-#
-#   NOTE: This parameter is deprecated and will do nothing if specified.
+#   NOTE: This parameter is deprecated and thorw a warning if specified.
 #
 # @param certname
 #   The puppet environment name of the system.
@@ -140,7 +135,7 @@ class pupmod (
   Simplib::Port                          $ca_port              = simplib::lookup('simp_options::puppet::ca_port', { 'default_value' => 8141 }),
   Simplib::Host                          $puppet_server        = simplib::lookup('simp_options::puppet::server', { 'default_value' => "puppet.${facts['domain']}" }),
   Simplib::ServerDistribution            $server_distribution  = simplib::lookup('simp_options::puppet::server_distribution', { 'default_value' => 'PC1' } ),
-  Integer                                $ca_crl_pull_interval = 2,
+  Optional                               $ca_crl_pull_interval = undef,
   Simplib::Host                          $certname             = $facts['fqdn'],
   String                                 $classfile            = '$vardir/classes.txt',
   Stdlib::AbsolutePath                   $confdir              = $::pupmod::params::puppet_config['confdir'],
@@ -177,7 +172,7 @@ class pupmod (
     validate_re($logdir,'^(\$(?!/)|/).+')
     validate_re($rundir,'^(\$(?!/)|/).+')
 
-    if $ca_crl_pull_interval != 2 {
+    if $ca_crl_pull_interval {
       deprecation('pupmod::ca_crl_pull_interval', 'pupmod::ca_crl_pull_interval is deprecated, the CRL cron job has been removed.')
     }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -178,7 +178,7 @@ class pupmod (
     validate_re($rundir,'^(\$(?!/)|/).+')
 
     if $ca_crl_pull_interval != 2 {
-      deprecation('pupmod::ca_crl_pull_interval', 'pupmod::ca_crl_pull_interval is depcrecated, the CRL cron job has been removed.')
+      deprecation('pupmod::ca_crl_pull_interval', 'pupmod::ca_crl_pull_interval is deprecated, the CRL cron job has been removed.')
     }
 
     if $haveged {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,14 @@
 #   The server distribution used. This changes the configuration based on whether
 #   we are using PC1 or PE
 #
+# @param ca_crl_pull_interval
+#   How many times per day to pull the CRL down from the CA via cron.
+#
+#   This uses ip_to_cron to randomize the pull interval so that the CA doesn't
+#   get swarmed.
+#
+#   NOTE: This parameter is deprecated and will do nothing if specified.
+#
 # @param certname
 #   The puppet environment name of the system.
 #
@@ -132,6 +140,7 @@ class pupmod (
   Simplib::Port                          $ca_port              = simplib::lookup('simp_options::puppet::ca_port', { 'default_value' => 8141 }),
   Simplib::Host                          $puppet_server        = simplib::lookup('simp_options::puppet::server', { 'default_value' => "puppet.${facts['domain']}" }),
   Simplib::ServerDistribution            $server_distribution  = simplib::lookup('simp_options::puppet::server_distribution', { 'default_value' => 'PC1' } ),
+  Integer                                $ca_crl_pull_interval = 2,
   Simplib::Host                          $certname             = $facts['fqdn'],
   String                                 $classfile            = '$vardir/classes.txt',
   Stdlib::AbsolutePath                   $confdir              = $::pupmod::params::puppet_config['confdir'],
@@ -167,6 +176,10 @@ class pupmod (
     validate_re($environmentpath,'^(\$(?!/)|/).+')
     validate_re($logdir,'^(\$(?!/)|/).+')
     validate_re($rundir,'^(\$(?!/)|/).+')
+
+    if $ca_crl_pull_interval != 2 {
+      deprecation('pupmod::ca_crl_pull_interval', 'pupmod::ca_crl_pull_interval is depcrecated, the CRL cron job has been removed.')
+    }
 
     if $haveged {
       include '::haveged'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pupmod",
-  "version": "7.3.2",
+  "version": "7.3.3",
   "author": "SIMP Team",
   "summary": "A puppet module to manage puppetserver and puppet agents",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pupmod",
-  "version": "7.3.3",
+  "version": "7.3.2",
   "author": "SIMP Team",
   "summary": "A puppet module to manage puppetserver and puppet agents",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -23,10 +23,6 @@ describe 'pupmod' do
             it { is_expected.to compile.with_all_deps }
             it { is_expected.not_to contain_class('haveged') }
             it { is_expected.to contain_package('puppet-agent').with_ensure('installed') }
-            it { is_expected.to contain_cron('puppet_crl_pull').with_command(
-              "/usr/bin/curl -sS --cert /etc/puppetlabs/puppet/ssl/certs/foo.example.com.pem --key /etc/puppetlabs/puppet/ssl/private_keys/foo.example.com.pem -k -o /etc/puppetlabs/puppet/ssl/crl.pem -H \"Accept: s\" https://1.2.3.4:8141/puppet-ca/v1/certificate_revocation_list/ca\n") }
-
-            it { is_expected.to contain_cron('puppet_crl_pull').with_user('root') }
             it { is_expected.to contain_class('pupmod::agent::cron') }
             it { is_expected.to contain_pupmod__conf('agent_daemonize').with({
               'section' => 'agent',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,13 @@ if !ENV.key?( 'TRUSTED_NODE_DATA' )
   ENV['TRUSTED_NODE_DATA']='yes'
 end
 
+
+if ENV['PUPPET_DEBUG']
+  Puppet::Util::Log.level = :debug
+  Puppet::Util::Log.newdestination(:console)
+end
+
+
 default_hiera_config =<<-EOM
 ---
 :backends:

--- a/templates/commands/crl_download.erb
+++ b/templates/commands/crl_download.erb
@@ -1,4 +1,0 @@
-<%
-  t_ca_server = @ca_server.gsub('$server',@puppet_server)
--%>
-/usr/bin/curl -sS --cert <%= @ssldir %>/certs/<%= @certname %>.pem --key <%= @ssldir %>/private_keys/<%= @certname %>.pem -k -o <%= @ssldir %>/crl.pem -H "Accept: s" https://<%= t_ca_server %>:<%= @ca_port %>/puppet-ca/v1/certificate_revocation_list/ca


### PR DESCRIPTION
The puppet agent now automatically pulls down the CRL from the
puppetserver when needed, and the cron job is no longer needed.

See: https://docs.puppet.com/puppet/latest/configuration.html#hostcrl

SIMP-3265 #close