### PR TITLE
(SIMP-3348) Auth.conf updates

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Jun 22 2017 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 7.3.2-0
+- fixed the path to the pki_files and krb_files in the auth.conf
+  so remote systems could download files.
+
 * Wed Jun 14 2017 Nick Miller <nick.miller@onyxpoint.com> - 7.3.2-0
 - Removed Puppet CRL download, the puppet agent now checks for the expiration of
   the cert automatically

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,16 +1,16 @@
-* Thu Jun 22 2017 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 7.3.2-0
+* Thu Jun 22 2017 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 7.3.1-0
 - fixed the path to the pki_files and krb_files in the auth.conf
   so remote systems could download files.
 
-* Wed Jun 14 2017 Nick Miller <nick.miller@onyxpoint.com> - 7.3.2-0
+* Wed Jun 14 2017 Nick Miller <nick.miller@onyxpoint.com> - 7.3.1-0
 - Removed Puppet CRL download, the puppet agent now checks for the expiration of
   the cert automatically
 
-* Mon Jun 05 2017 Nick Markowski <nmarkowski@keywcorp.com> - 7.3.2-0
+* Mon Jun 05 2017 Nick Markowski <nmarkowski@keywcorp.com> - 7.3.1-0
 - Ensure legacy auth.conf is backed up before removing it. This is a
   follow up to SIMP-3049 based on feedback to SIMP-3196.
 
-* Mon May 22 2017 Kendall Moore <kendall.moore@onyxpoint.com> 7.3.2-0
+* Mon May 22 2017 Kendall Moore <kendall.moore@onyxpoint.com> 7.3.1-0
 - Added manifest to manage simp-specific puppet master auth requirements
 - Disabled puppetserver setting to enable legacy auth.conf by default
 - Remove legacy auth.conf placed by the `puppet-agent` package

--- a/manifests/master/simp_auth.pp
+++ b/manifests/master/simp_auth.pp
@@ -129,7 +129,7 @@ class pupmod::master::simp_auth (
     notify               => Service[$_master_service],
   }
 
-  puppet_authorization::rule { 'Allow access to each hosts own kerberos keytabs from the krb_files module':
+  puppet_authorization::rule { 'Allow access to each hosts own kerberos keytabs from the krb5_files module':
     ensure               => $bool2ensure[$krb5_keytabs_from_host],
     match_request_path   => '^/puppet/v3/file_(metadata|content)/modules/krb5_files/keytabs/([^/]+)',
     match_request_type   => 'regex',

--- a/manifests/master/simp_auth.pp
+++ b/manifests/master/simp_auth.pp
@@ -87,7 +87,7 @@ class pupmod::master::simp_auth (
 
   puppet_authorization::rule { 'Allow access to each hosts own kerberos keytabs from the legacy location':
     ensure               => $bool2ensure[$legacy_pki_keytabs_from_host],
-    match_request_path   => '^/puppet/v3/file_(metadata|content)/pki_files/keytabs/([^/]+)',
+    match_request_path   => '^/puppet/v3/file_(metadata|content)/modules/pki_files/keytabs/([^/]+)',
     match_request_type   => 'regex',
     match_request_method => ['get'],
     allow                => '$2',
@@ -98,7 +98,7 @@ class pupmod::master::simp_auth (
 
   puppet_authorization::rule { 'Allow access to the cacerts from the pki_files module from all hosts':
     ensure               => $bool2ensure[$pki_cacerts_all],
-    match_request_path   => '^/puppet/v3/file_(metadata|content)/pki_files/keydist/cacerts',
+    match_request_path   => '^/puppet/v3/file_(metadata|content)/modules/pki_files/keydist/cacerts',
     match_request_type   => 'regex',
     match_request_method => ['get'],
     allow                => '*',
@@ -109,7 +109,7 @@ class pupmod::master::simp_auth (
 
   puppet_authorization::rule { 'Allow access to the mcollective PKI from the pki_files module from all hosts':
     ensure               => $bool2ensure[$pki_mcollective_all],
-    match_request_path   => '^/puppet/v3/file_(metadata|content)/pki_files/keydist/mcollective',
+    match_request_path   => '^/puppet/v3/file_(metadata|content)/modules/pki_files/keydist/mcollective',
     match_request_type   => 'regex',
     match_request_method => ['get'],
     allow                => '*',
@@ -131,7 +131,7 @@ class pupmod::master::simp_auth (
 
   puppet_authorization::rule { 'Allow access to each hosts own kerberos keytabs from the pki_files module':
     ensure               => $bool2ensure[$krb5_keytabs_from_host],
-    match_request_path   => '^/puppet/v3/file_(metadata|content)/krb5_files/keytabs/([^/]+)',
+    match_request_path   => '^/puppet/v3/file_(metadata|content)/modules/krb5_files/keytabs/([^/]+)',
     match_request_type   => 'regex',
     match_request_method => ['get'],
     allow                => '$2',

--- a/manifests/master/simp_auth.pp
+++ b/manifests/master/simp_auth.pp
@@ -129,7 +129,7 @@ class pupmod::master::simp_auth (
     notify               => Service[$_master_service],
   }
 
-  puppet_authorization::rule { 'Allow access to each hosts own kerberos keytabs from the pki_files module':
+  puppet_authorization::rule { 'Allow access to each hosts own kerberos keytabs from the krb_files module':
     ensure               => $bool2ensure[$krb5_keytabs_from_host],
     match_request_path   => '^/puppet/v3/file_(metadata|content)/modules/krb5_files/keytabs/([^/]+)',
     match_request_type   => 'regex',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pupmod",
-  "version": "7.3.2",
+  "version": "7.3.1",
   "author": "SIMP Team",
   "summary": "A puppet module to manage puppetserver and puppet agents",
   "license": "Apache-2.0",

--- a/spec/classes/master/simp_auth_spec.rb
+++ b/spec/classes/master/simp_auth_spec.rb
@@ -19,7 +19,7 @@ describe 'pupmod::master::simp_auth' do
         }) }
         it { is_expected.to create_puppet_authorization__rule('Allow access to the cacerts from the pki_files module from all hosts').with({
           'ensure'               => 'present',
-          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/pki_files/keydist/cacerts',
+          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/pki_files/keydist/cacerts',
           'match_request_type'   => 'regex',
           'match_request_method' => ['get'],
           'allow'                => '*',
@@ -35,7 +35,7 @@ describe 'pupmod::master::simp_auth' do
         }) }
         it { is_expected.to create_puppet_authorization__rule('Allow access to the mcollective PKI from the pki_files module from all hosts').with({
           'ensure'               => 'present',
-          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/pki_files/keydist/mcollective',
+          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/pki_files/keydist/mcollective',
           'match_request_type'   => 'regex',
           'match_request_method' => ['get'],
           'allow'                => '*',
@@ -51,7 +51,7 @@ describe 'pupmod::master::simp_auth' do
         }) }
         it { is_expected.to create_puppet_authorization__rule('Allow access to each hosts own kerberos keytabs from the legacy location').with({
           'ensure'               => 'absent',
-          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/pki_files/keytabs/([^/]+)',
+          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/pki_files/keytabs/([^/]+)',
           'match_request_type'   => 'regex',
           'match_request_method' => ['get'],
           'allow'                => '$2',
@@ -59,7 +59,7 @@ describe 'pupmod::master::simp_auth' do
         }) }
         it { is_expected.to create_puppet_authorization__rule('Allow access to each hosts own kerberos keytabs from the pki_files module').with({
           'ensure'               => 'present',
-          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/krb5_files/keytabs/([^/]+)',
+          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/krb5_files/keytabs/([^/]+)',
           'match_request_type'   => 'regex',
           'match_request_method' => ['get'],
           'allow'                => '$2',
@@ -72,7 +72,7 @@ describe 'pupmod::master::simp_auth' do
         let(:params) {{ :server_distribution => 'PE' }}
         it { is_expected.to create_puppet_authorization__rule('Allow access to each hosts own kerberos keytabs from the pki_files module').with({
           'ensure'               => 'present',
-          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/krb5_files/keytabs/([^/]+)',
+          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/krb5_files/keytabs/([^/]+)',
           'match_request_type'   => 'regex',
           'match_request_method' => ['get'],
           'allow'                => '$2',

--- a/spec/classes/master/simp_auth_spec.rb
+++ b/spec/classes/master/simp_auth_spec.rb
@@ -57,7 +57,7 @@ describe 'pupmod::master::simp_auth' do
           'allow'                => '$2',
           'sort_order'           => 450,
         }) }
-        it { is_expected.to create_puppet_authorization__rule('Allow access to each hosts own kerberos keytabs from the pki_files module').with({
+        it { is_expected.to create_puppet_authorization__rule('Allow access to each hosts own kerberos keytabs from the krb5_files module').with({
           'ensure'               => 'present',
           'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/krb5_files/keytabs/([^/]+)',
           'match_request_type'   => 'regex',
@@ -70,7 +70,7 @@ describe 'pupmod::master::simp_auth' do
 
       context 'on PE' do
         let(:params) {{ :server_distribution => 'PE' }}
-        it { is_expected.to create_puppet_authorization__rule('Allow access to each hosts own kerberos keytabs from the pki_files module').with({
+        it { is_expected.to create_puppet_authorization__rule('Allow access to each hosts own kerberos keytabs from the krb5_files module').with({
           'ensure'               => 'present',
           'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/krb5_files/keytabs/([^/]+)',
           'match_request_type'   => 'regex',


### PR DESCRIPTION
  The clients can not access the ca certs because the path is wrong in
  the auth.conf.  It needs "/modules/" in it.  I update the krb5_files path also.

SIMP-3348 #close