### PR TITLE
(SIMP-3283) auth.conf README updates

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 * Thu Jul 27 2017 Nick Markowski <nmarkowski@keywcorp.com> - 7.3.2-0
-- Updated the README with instructions to back up legacy auth.conf 
-  and modify new auth.conf, need be.
+- README updates:
+  - Informed users of legacy auth.conf deprecation
+  - Provided instructions to reproduce custom auth.conf entries
+    in puppet
 
 * Thu Jun 22 2017 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 7.3.1-0
 - fixed the path to the pki_files and krb_files in the auth.conf

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Jul 27 2017 Nick Markowski <nmarkowski@keywcorp.com> - 7.3.2-0
+- Updated the README with instructions to back up legacy auth.conf 
+  and modify new auth.conf, need be.
+
 * Thu Jun 22 2017 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 7.3.1-0
 - fixed the path to the pki_files and krb_files in the auth.conf
   so remote systems could download files.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ Please read our [Contribution Guide](https://simp-project.atlassian.net/wiki/dis
 
 ## Upgrading From 7.3.0 Or Earlier
 
-If you intend to upgrade from version 7.3.0-0 or earlier, you should:
+Legacy auth.conf, `/etc/puppetlabs/puppet/auth.conf`, has been deprecated.
+`pupmod-simp-pupmod` will back up legacy puppet auth.conf after upgrade.
 
-1. Back up legacy puppet auth.conf, `<puppet confdir>/auth.conf`, before upgrade.
-
-2. Re-produce any custom work done to legacy auth.conf in the new auth.conf, via the `puppet_authorization::rule` define.  The stock rules are managed in `pupmod::master::simp_auth`.
+The puppetserver's auth.conf is now managed by Puppet. You will need to
+re-produce any custom work done to legacy auth.conf in the new auth.conf, via
+the `puppet_authorization::rule` define.  The stock rules are managed in
+`pupmod::master::simp_auth`.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ If you find any issues, they can be submitted to our [JIRA](https://simp-project
 
 Please read our [Contribution Guide](https://simp-project.atlassian.net/wiki/display/SD/Contributing+to+SIMP) and visit our [developer wiki](https://simp-project.atlassian.net/wiki/display/SD/SIMP+Development+Home).
 
-## Work in Progress
+## Upgrading From 7.3.0 Or Earlier
 
-Please excuse us as we transition this code into the public domain.
+If you intend to upgrade from version 7.3.0-0 or earlier, you should:
 
-Downloads, discussion, and patches are still welcome!
+1. Back up legacy puppet auth.conf, `<puppet confdir>/auth.conf`, before upgrade.
+
+2. Re-produce any custom work done to legacy auth.conf in the new auth.conf, via the `puppet_authorization::rule` define.  The stock rules are managed in `pupmod::master::simp_auth`.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pupmod",
-  "version": "7.3.1",
+  "version": "7.3.2",
   "author": "SIMP Team",
   "summary": "A puppet module to manage puppetserver and puppet agents",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Updated the README with instructions to back up legacy auth.conf
  and modify new auth.conf, need be.

SIMP-3283 #comment Modified README