### PR TITLE
(SIMP-3460) pupmod: remove OBE CRL pull cron job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,10 @@ cache: bundler
 before_script:
   - bundle update
 bundler_args: --without development system_tests --path .vendor
-before_install: rm Gemfile.lock || true
+before_install: 
+  - rm Gemfile.lock || true
+  - rvm @global do gem uninstall bundler -a -x
+  - rvm @global do gem install bundler -v '~> 1.14.0'
 script:
   - bundle exec rake test
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,7 @@ cache: bundler
 before_script:
   - bundle update
 bundler_args: --without development system_tests --path .vendor
-before_install: 
-  - rm Gemfile.lock || true
-  - rvm @global do gem uninstall bundler -a -x
-  - rvm @global do gem install bundler -v '~> 1.14.0'
+before_install: rm Gemfile.lock || true
 script:
   - bundle exec rake test
 notifications:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Aug 01 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 7.3.2-0
+- Ensure OBE 'puppet_crl_pull' cron job from pupmod versions prior
+  to 7.3.1 is removed.
+
 * Thu Jul 27 2017 Nick Markowski <nmarkowski@keywcorp.com> - 7.3.2-0
 - README updates:
   - Informed users of legacy auth.conf deprecation

--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,8 @@ group :test do
   gem 'puppet-strings'
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
-  gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 1.3')
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 3.5')
+  gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 2.0')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 4.0')
 end
 
 group :development do

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,7 +22,7 @@
 #   we are using PC1 or PE
 #
 # @param ca_crl_pull_interval
-#   NOTE: This parameter is deprecated and thorw a warning if specified.
+#   NOTE: This parameter is deprecated and throws a warning if specified.
 #
 # @param certname
 #   The puppet environment name of the system.
@@ -361,5 +361,10 @@ class pupmod (
       }
     }
   }
+
+  # Make sure OBE cron job from pupmod versions prior to 7.3.1 is removed.
+  # This resource can be removed when the OBE ca_crl_pull_interval
+  # parameter is removed.
+  cron { 'puppet_crl_pull': ensure => 'absent' }
 }
 # vim: set expandtab ts=2 sw=2:

--- a/spec/classes/agent/cron_spec.rb
+++ b/spec/classes/agent/cron_spec.rb
@@ -5,7 +5,7 @@ describe 'pupmod::agent::cron' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
 
-      let(:facts) { os_facts }
+      let(:facts) { os_facts.merge(:ipaddress => '10.0.2.15') }
 
       context 'using general parameters' do
         let(:params) {{ :interval => 60 }}

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -42,12 +42,12 @@ describe 'pupmod' do
 
             it { is_expected.to contain_pupmod__conf('srv_domain').with({
               'setting' => 'srv_domain',
-              'value' => 'example.com'
+              'value' => facts[:domain]
             }) }
 
             it { is_expected.to contain_pupmod__conf('certname').with({
               'setting' => 'certname',
-              'value' => 'foo.example.com'
+              'value' => facts[:fqdn]
             }) }
 
             it { is_expected.to contain_pupmod__conf('vardir').with({
@@ -141,6 +141,9 @@ describe 'pupmod' do
                 is_expected.to contain_selboolean('puppetagent_manage_all_files')
               end
             end
+
+            it { is_expected.to contain_cron('puppet_crl_pull').with_ensure('absent') }
+
             context 'with_selinux_disabled' do
               let(:facts) {
                 _facts = @extras.merge(os_facts)

--- a/spec/classes/master/base_spec.rb
+++ b/spec/classes/master/base_spec.rb
@@ -58,8 +58,10 @@ describe 'pupmod::master::base' do
             }
           )
         }
-        puppetserver_clear_environment_cache = File.open("#{File.dirname(__FILE__)}/data/puppetserver_clear_environment_cache.txt", "rb").read;
-        it { is_expected.to contain_file('/usr/local/sbin/puppetserver_clear_environment_cache').with_content(puppetserver_clear_environment_cache) }
+        it { 
+          puppetserver_clear_environment_cache = File.open("#{File.dirname(__FILE__)}/data/puppetserver_clear_environment_cache.txt", "rb").read.gsub('foo.example.com', facts[:fqdn])
+          is_expected.to contain_file('/usr/local/sbin/puppetserver_clear_environment_cache').with_content(puppetserver_clear_environment_cache)
+        }
 
         it { is_expected.to contain_file('/usr/local/sbin/puppetserver_reload').with(
             {
@@ -70,8 +72,10 @@ describe 'pupmod::master::base' do
             }
           )
         }
-        puppetserver_reload = File.open("#{File.dirname(__FILE__)}/data/puppetserver_reload.txt", "rb").read;
-        it { is_expected.to contain_file('/usr/local/sbin/puppetserver_reload').with_content(puppetserver_reload) }
+        it { 
+          puppetserver_reload = File.open("#{File.dirname(__FILE__)}/data/puppetserver_reload.txt", "rb").read.gsub('foo.example.com', facts[:fqdn])
+          is_expected.to contain_file('/usr/local/sbin/puppetserver_reload').with_content(puppetserver_reload) 
+        }
 
         it { is_expected.to contain_group('puppet').with(
             {

--- a/spec/classes/master/sysconfig_spec.rb
+++ b/spec/classes/master/sysconfig_spec.rb
@@ -10,7 +10,7 @@ describe 'pupmod::master::sysconfig' do
     end
     context "on #{os}" do
 
-      let(:facts){ @extras.merge(os_facts) }
+      let(:facts){ @extras.merge(os_facts).merge(:memorysize_mb => '490.16') }
 
       context 'with default parameters' do
           puppetserver_content = File.open("#{File.dirname(__FILE__)}/data/puppetserver.txt", "rb").read;

--- a/spec/classes/master_spec.rb
+++ b/spec/classes/master_spec.rb
@@ -100,7 +100,7 @@ puppetlabs.services.ca.certificate-authority-service/certificate-authority-servi
           'owner'   => 'root',
           'group'   => 'puppet',
           'mode'    => '0640',
-          'content' => %q~# This file managed by Puppet
+          'content' => %Q~# This file managed by Puppet
 # Any changes will be removed on the next run
 
 # CA-related settings
@@ -113,7 +113,7 @@ certificate-authority: {
         # have access to the certificate_status endpoint.  Any requests made to
         # this endpoint that do not present a valid client cert mentioned in
         # this list will be denied access.
-        client-whitelist: [foo.example.com]
+        client-whitelist: [#{facts[:fqdn]}]
         authorization-required: true
     }
 }
@@ -128,7 +128,7 @@ certificate-authority: {
           'owner'   => 'root',
           'group'   => 'puppet',
           'mode'    => '0640',
-          'content' => %q~# This file managed by Puppet
+          'content' => %Q~# This file managed by Puppet
 # Any changes will be removed on the next run
 
 # configuration for the JRuby interpreters
@@ -193,7 +193,7 @@ profiler: {
 
 # Settings related to the puppet-admin HTTP API
 puppet-admin: {
-    client-whitelist: [foo.example.com]
+    client-whitelist: [#{facts[:fqdn]}]
 }
 ~,
           'require' => 'Package[puppetserver]',
@@ -232,7 +232,7 @@ web-router-service: {
           'owner'   => 'root',
           'group'   => 'puppet',
           'mode'    => '0640',
-          'content' => %q~# This file managed by Puppet
+          'content' => %Q~# This file managed by Puppet
 # Any changes will be removed on the next run
 webserver: {
   base: {
@@ -240,8 +240,8 @@ webserver: {
     client-auth: need
     ssl-crl-path: /etc/puppetlabs/puppet/ssl/crl.pem
     ssl-ca-cert: /etc/puppetlabs/puppet/ssl/certs/ca.pem
-    ssl-cert: /etc/puppetlabs/puppet/ssl/certs/foo.example.com.pem
-    ssl-key: /etc/puppetlabs/puppet/ssl/private_keys/foo.example.com.pem
+    ssl-cert: /etc/puppetlabs/puppet/ssl/certs/#{facts[:fqdn]}.pem
+    ssl-key: /etc/puppetlabs/puppet/ssl/private_keys/#{facts[:fqdn]}.pem
     ssl-host: 0.0.0.0
     ssl-port: 8140
     default-server: true
@@ -251,8 +251,8 @@ webserver: {
     client-auth: want
     ssl-crl-path: /etc/puppetlabs/puppet/ssl/crl.pem
     ssl-ca-cert: /etc/puppetlabs/puppet/ssl/certs/ca.pem
-    ssl-cert: /etc/puppetlabs/puppet/ssl/certs/foo.example.com.pem
-    ssl-key: /etc/puppetlabs/puppet/ssl/private_keys/foo.example.com.pem
+    ssl-cert: /etc/puppetlabs/puppet/ssl/certs/#{facts[:fqdn]}.pem
+    ssl-key: /etc/puppetlabs/puppet/ssl/private_keys/#{facts[:fqdn]}.pem
     ssl-host: 0.0.0.0
     ssl-port: 8141
   }
@@ -605,7 +605,7 @@ web-router-service: {
             'owner'   => 'root',
             'group'   => 'puppet',
             'mode'    => '0640',
-            'content' => %q~# This file managed by Puppet
+            'content' => %Q~# This file managed by Puppet
 # Any changes will be removed on the next run
 webserver: {
   ca: {
@@ -613,8 +613,8 @@ webserver: {
     client-auth: want
     ssl-crl-path: /etc/puppetlabs/puppet/ssl/crl.pem
     ssl-ca-cert: /etc/puppetlabs/puppet/ssl/certs/ca.pem
-    ssl-cert: /etc/puppetlabs/puppet/ssl/certs/foo.example.com.pem
-    ssl-key: /etc/puppetlabs/puppet/ssl/private_keys/foo.example.com.pem
+    ssl-cert: /etc/puppetlabs/puppet/ssl/certs/#{facts[:fqdn]}.pem
+    ssl-key: /etc/puppetlabs/puppet/ssl/private_keys/#{facts[:fqdn]}.pem
     ssl-host: 0.0.0.0
     ssl-port: 8141
     default-server: true
@@ -634,7 +634,7 @@ webserver: {
             'owner'   => 'root',
             'group'   => 'puppet',
             'mode'    => '0640',
-            'content' => %q~# This file managed by Puppet
+            'content' => %Q~# This file managed by Puppet
 # Any changes will be removed on the next run
 webserver: {
   base: {
@@ -642,8 +642,8 @@ webserver: {
     client-auth: need
     ssl-crl-path: /etc/puppetlabs/puppet/ssl/crl.pem
     ssl-ca-cert: /etc/puppetlabs/puppet/ssl/certs/ca.pem
-    ssl-cert: /etc/puppetlabs/puppet/ssl/certs/foo.example.com.pem
-    ssl-key: /etc/puppetlabs/puppet/ssl/private_keys/foo.example.com.pem
+    ssl-cert: /etc/puppetlabs/puppet/ssl/certs/#{facts[:fqdn]}.pem
+    ssl-key: /etc/puppetlabs/puppet/ssl/private_keys/#{facts[:fqdn]}.pem
     ssl-host: 0.0.0.0
     ssl-port: 8140
     default-server: true
@@ -663,7 +663,7 @@ webserver: {
             'owner'   => 'root',
             'group'   => 'puppet',
             'mode'    => '0640',
-            'content' => %q~# This file managed by Puppet
+            'content' => %Q~# This file managed by Puppet
 # Any changes will be removed on the next run
 webserver: {
   base: {
@@ -671,8 +671,8 @@ webserver: {
     client-auth: want
     ssl-crl-path: /etc/puppetlabs/puppet/ssl/crl.pem
     ssl-ca-cert: /etc/puppetlabs/puppet/ssl/certs/ca.pem
-    ssl-cert: /etc/puppetlabs/puppet/ssl/certs/foo.example.com.pem
-    ssl-key: /etc/puppetlabs/puppet/ssl/private_keys/foo.example.com.pem
+    ssl-cert: /etc/puppetlabs/puppet/ssl/certs/#{facts[:fqdn]}.pem
+    ssl-key: /etc/puppetlabs/puppet/ssl/private_keys/#{facts[:fqdn]}.pem
     ssl-host: 0.0.0.0
     ssl-port: 12345
     default-server: true


### PR DESCRIPTION
- Added resource that ensures OBB CRL pull cron job is absent
- Updated to facter 2.5 and simp-rspec-puppet-facts 2.0.0
- Pinned version of bundler to a version that works when FIPS mode
  is enabled
- Fixed tests that were hardcoded to specific  values,
  instead of using the actual fact test values.

SIMP-3460 #close