### PR TITLE
(SIMP-3280) Add SHA256-based random minute option to agent cron

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -20,11 +20,7 @@ fixtures:
     rsync: https://github.com/simp/pupmod-simp-rsync
     rsyslog: https://github.com/simp/pupmod-simp-rsyslog
     simpcat: https://github.com/simp/pupmod-simp-simpcat
-#FIXME:  Revert to master, once SIMP-3280 is merged
-#    simplib: https://github.com/simp/pupmod-simp-simplib
-    simplib: 
-      repo: https://github.com/lnemsick-simp/pupmod-simp-simplib
-      branch: SIMP-3280
+    simplib: https://github.com/simp/pupmod-simp-simplib
     stdlib: https://github.com/simp/puppetlabs-stdlib
     puppet_enterprise:
       repo: https://github.com/simp/pupmod-mock-puppet_enterprise

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -20,7 +20,11 @@ fixtures:
     rsync: https://github.com/simp/pupmod-simp-rsync
     rsyslog: https://github.com/simp/pupmod-simp-rsyslog
     simpcat: https://github.com/simp/pupmod-simp-simpcat
-    simplib: https://github.com/simp/pupmod-simp-simplib
+#FIXME:  Revert to master, once SIMP-3280 is merged
+#    simplib: https://github.com/simp/pupmod-simp-simplib
+    simplib: 
+      repo: https://github.com/lnemsick-simp/pupmod-simp-simplib
+      branch: SIMP-3280
     stdlib: https://github.com/simp/puppetlabs-stdlib
     puppet_enterprise:
       repo: https://github.com/simp/pupmod-mock-puppet_enterprise

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,16 @@
-* Tue Aug 01 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 7.3.2-0
+* Mon Sep 11 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 7.4.0-0
+- Add SHA256-based option to generate the minute parameter for
+  a client's puppet agent cron from its IP address. This option
+  is intended mitigate the undesirable clustering of client puppet
+  agent runs, when the number of IPs to be transformed is less
+  than the minute range over which the randomization is requested
+  (60) and/or the client IPs are not linearly assigned.
+
+* Tue Aug 01 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 7.4.0-0
 - Ensure OBE 'puppet_crl_pull' cron job from pupmod versions prior
   to 7.3.1 is removed.
 
-* Thu Jul 27 2017 Nick Markowski <nmarkowski@keywcorp.com> - 7.3.2-0
+* Thu Jul 27 2017 Nick Markowski <nmarkowski@keywcorp.com> - 7.4.0-0
 - README updates:
   - Informed users of legacy auth.conf deprecation
   - Provided instructions to reproduce custom auth.conf entries

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -14,6 +14,6 @@ Requires: pupmod-simp-pki >= 6.0.0-0
 Requires: pupmod-simp-simpcat < 7.0.0-0
 Requires: pupmod-simp-simpcat >= 6.0.0-0
 Requires: pupmod-simp-simplib < 4.0.0-0
-Requires: pupmod-simp-simplib >= 3.1.0-0
+Requires: pupmod-simp-simplib >= 3.5.0-0
 Requires: pupmod-simp-tcpwrappers < 7.0.0-0
 Requires: pupmod-simp-tcpwrappers >= 6.0.0-0

--- a/manifests/agent/cron.pp
+++ b/manifests/agent/cron.pp
@@ -46,7 +46,7 @@
 #
 #   Set to one of the randiomization algorithms if you want the minute
 #   to be auto-generated from ``$minute_base``:
-# 
+#
 #   ``ip_mod`` or its backward-compatible alias ``rand`` uses a
 #   IP-modulus-based transformation of the numeric IP representation of
 #   ``$minute_base``, when ``$minute_base`` is an IP address.
@@ -55,11 +55,9 @@
 #   Puppet master exceeds 60 and the hosts have linearly-assigned IP
 #   addresses.
 #
-#   ``sha256`` uses a SHA256-based transformation of either
-#   ``$minute_base`` or, if ``$minute_base`` is an IP address, the
-#   numeric IP representation of ``$minute_base``.  This algorithm
-#   provides general randomization for cases in which ``ip_mod`` yields
-#   undesirable clustering.
+#   ``sha256`` uses a SHA256-based transformation ``$minute_base``.
+#   This algorithm provides general randomization for cases in which
+#   ``ip_mod`` yields undesirable clustering.
 #
 # @param hour
 #   The ``hour`` value for the crontab entry
@@ -98,7 +96,7 @@
 #
 #   * This only takes effect if ``$break_puppet_lock`` is true
 #
-#   * When not set, an appropriate value is computed based on 
+#   * When not set, an appropriate value is computed based on
 #     cron frequency and ``$maxruntime``.
 #
 # @example Configure puppet agent cron to run every 20 minutes

--- a/manifests/agent/cron.pp
+++ b/manifests/agent/cron.pp
@@ -3,13 +3,11 @@
 # @param interval
 #   The cron iteration time (in minutes) for running puppet
 #
-#   * This applies the standard ``*/$interval`` style syntax from cron
+#   * When ``$minute`` is set to 'nil', this applies the standard
+#     ``*/$interval`` style syntax from cron for the minute field.
+#     See ``crontab(5)`` for additional details.
 #
-#   * See ``crontab(5)`` for additional details
-#
-#   * NOTE: This is overridden if ``$minute`` is set to anything other than
-#     ``nil`` or ``rand``.  If this is the case, it is assumed that you want
-#     finer control over your puppet run.
+#   * Otherwise, this value is ignored.
 #
 # @param minute_base
 #   The default artifact to use to auto-generate a cron interval
@@ -25,25 +23,48 @@
 #   * WARNING: If this is the *same* resolved value on all of your systems then
 #     your systems will have the *same* run interval.
 #
+#   * Not used if using ``$interval``
+#
 # @param run_timeframe
 #   The time frame within which you wish to run the puppet agent
 #
 #   * This directly translates to the minute field of the cron job so this
 #     should probably be left at 60
 #
+#   * Not used if using ``$interval``
+#
 # @param runs_per_timeframe
 #   The number of times, per ``$timeframe``, that you want to run the Puppet
 #   Agent.
 #
+#   * Not used if using ``$interval``
+#
 # @param minute
 #   The ``minute`` value for the crontab entry
 #
-#   Set to ``nil`` if you want to use $interval
+#   Set to ``nil`` if you want to only use ``$interval``.
+#
+#   Set to one of the randiomization algorithms if you want the minute
+#   to be auto-generated from ``$minute_base``:
+# 
+#   ``ip_mod`` or its backward-compatible alias ``rand`` uses a
+#   IP-modulus-based transformation of the numeric IP representation of
+#   ``$minute_base``, when ``$minute_base`` is an IP address.
+#   Otherwise, it uses a crc32-based transformation of $minute_base.
+#   This algorithm works well when the number of hosts managed by a
+#   Puppet master exceeds 60 and the hosts have linearly-assigned IP
+#   addresses.
+#
+#   ``sha256`` uses a SHA256-based transformation of either
+#   ``$minute_base`` or, if ``$minute_base`` is an IP address, the
+#   numeric IP representation of ``$minute_base``.  This algorithm
+#   provides general randomization for cases in which ``ip_mod`` yields
+#   undesirable clustering.
 #
 # @param hour
 #   The ``hour`` value for the crontab entry
 #
-#   Not used if using ``$interval``
+#   * Not used if using ``$interval``
 #
 # @param monthday
 #   The ``monthday`` value for the crontab entry
@@ -77,12 +98,36 @@
 #
 #   * This only takes effect if ``$break_puppet_lock`` is true
 #
+#   * When not set, an appropriate value is computed based on 
+#     cron frequency and ``$maxruntime``.
+#
+# @example Configure puppet agent cron to run every 20 minutes
+#
+#   class { 'pupmod::agent::cron:
+#     interval => 20,
+#     minute   => 'nil'
+#   }
+#
+# @example Configure puppet agent cron to run once an hour using
+#   the default minute randomization algorithm
+#
+#   class { 'pupmod::agent::cron:
+#     runs_per_timeframe => 1
+#   }
+#
+# @example Configure cron to run once per day at a particular time
+#
+#   class { 'pupmod::agent::cron:
+#     minute => '23'
+#     hour   => '4'
+#   }
+#
 class pupmod::agent::cron (
   Integer[0]            $interval           = 30,
   String                $minute_base        = $facts['ipaddress'],
   Integer[0]            $run_timeframe      = 60,
   Integer[0]            $runs_per_timeframe = 2,
-  Variant[Array,String] $minute             = 'rand',
+  Variant[Array,String] $minute             = 'ip_mod',
   Variant[Array,String] $hour               = '*',
   Variant[Array,String] $monthday           = '*',
   Variant[Array,String] $month              = '*',
@@ -97,9 +142,14 @@ class pupmod::agent::cron (
   cron { 'puppetd': ensure => 'absent' }
 
   case $minute {
-    'rand'  : {
+    # rand = ip_mod for backward compatibility
+    'ip_mod', 'rand' : {
       $_max_disable_base = $maxruntime + ($run_timeframe / $runs_per_timeframe)
-      $_minute           = rand_cron($minute_base,$runs_per_timeframe,$run_timeframe)
+      $_minute           = simplib::rand_cron($minute_base,'ip_mod',$runs_per_timeframe,$run_timeframe-1)
+    }
+    'sha256' : {
+      $_max_disable_base = $maxruntime + ($run_timeframe / $runs_per_timeframe)
+      $_minute           = simplib::rand_cron($minute_base,'sha256',$runs_per_timeframe,$run_timeframe-1)
     }
     'nil'   : {
       $_max_disable_base = $maxruntime + $interval

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pupmod",
-  "version": "7.3.2",
+  "version": "7.4.0",
   "author": "SIMP Team",
   "summary": "A puppet module to manage puppetserver and puppet agents",
   "license": "Apache-2.0",
@@ -43,7 +43,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.1.0 < 4.0.0"
+      "version_requirement": ">= 3.5.0 < 4.0.0"
     },
     {
       "name": "simp/pki",

--- a/spec/classes/agent/cron_spec.rb
+++ b/spec/classes/agent/cron_spec.rb
@@ -58,7 +58,7 @@ describe 'pupmod::agent::cron' do
 
         it { is_expected.to contain_cron('puppetagent').with({
           'command'   => '/usr/local/bin/puppetagent_cron.sh',
-          'minute'    => [11,41],
+          'minute'    => [10,40],
           'hour'      => '*',
           'monthday'  => '*',
           'month'     => '*',

--- a/spec/classes/agent/cron_spec.rb
+++ b/spec/classes/agent/cron_spec.rb
@@ -2,58 +2,140 @@
 require 'spec_helper'
 
 describe 'pupmod::agent::cron' do
+
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
 
       let(:facts) { os_facts.merge(:ipaddress => '10.0.2.15') }
 
-      context 'using general parameters' do
-        let(:params) {{ :interval => 60 }}
-
+      context 'with default parameters' do
         it { is_expected.to create_class('pupmod::agent::cron') }
-        it { is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/-gt 14400/) }
-        it { is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(
-          /service puppet stop > \/dev\/null 2>&1/
-        )}
-        it { is_expected.to contain_cron('puppetd').with(
-            {
-              "ensure" => "absent",
-            }
-          )
-        }
+        it { is_expected.to contain_cron('puppetd').with_ensure("absent") }
         it { is_expected.to contain_cron('puppetagent').with({
-            'minute'    => [27,57],
-            'hour'      => '*',
-            'monthday'  => '*',
-            'month'     => '*',
-            'weekday'   => '*'
+          'command'   => '/usr/local/bin/puppetagent_cron.sh',
+          'minute'    => [27,57],
+          'hour'      => '*',
+          'monthday'  => '*',
+          'month'     => '*',
+          'weekday'   => '*'
         })}
 
-        context 'use_alternate_minute_base' do
-          let(:params) {{ :minute_base => 'foo' }}
-          it { is_expected.to contain_cron('puppetagent').with({
-              'minute'    => [29,59],
-              'hour'      => '*',
-              'monthday'  => '*',
-              'month'     => '*',
-              'weekday'   => '*'
-          })}
+        it 'uses maxruntime to kill processes in puppetagent_cron.sh' do
+          expected = Regexp.escape('if [[ -n "${pup_status}" && $(( ${now} - ${filedate} )) -gt 1440')
+          is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/#{expected}/)
         end
 
-        context 'set_max_age' do
-          let(:params) {{ :maxruntime => 10 }}
-          it { is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/-gt 600/) }
+        it 'includes code to break an existing puppet lock in puppetagent_cron.sh' do
+          is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/handles forcibly enabling puppet agent/)
         end
 
-        context 'set_max_age' do
-          let(:params) {{ :maxruntime => 10 }}
-          it { is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/-gt 600/) }
+        it 'uses a computed max disable time to enable puppet in puppetagent_cron.sh' do
+          expected = Regexp.escape('if [[ ${pup_status} -ne 0 && $(( ${now} - ${filedate} )) -gt 16200')
+          is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/#{expected}/)
         end
+      end
 
-        context 'disable break_puppet_lock' do
-          let(:params) {{ :break_puppet_lock => false }}
-          it { is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/handles puppet processes which have been running longer than maxruntime/) }
-          it { is_expected.to_not contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/handles forcibly enabling puppet agent/) }
+      context "with 'rand' randomization algorithm for cron minute" do
+        let(:params) {{ :minute => 'rand' }}
+
+        it { is_expected.to contain_cron('puppetagent').with({
+          'command'   => '/usr/local/bin/puppetagent_cron.sh',
+          'minute'    => [27,57],
+          'hour'      => '*',
+          'monthday'  => '*',
+          'month'     => '*',
+          'weekday'   => '*'
+        })}
+
+        it 'uses a computed max disable time to enable puppet in puppetagent_cron.sh' do
+          expected = Regexp.escape('if [[ ${pup_status} -ne 0 && $(( ${now} - ${filedate} )) -gt 16200')
+          is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/#{expected}/)
+        end
+      end
+
+      context "with 'sha256' randomization algorithm for minute" do
+        let(:params) {{ :minute => 'sha256' }}
+
+        it { is_expected.to contain_cron('puppetagent').with({
+          'command'   => '/usr/local/bin/puppetagent_cron.sh',
+          'minute'    => [11,41],
+          'hour'      => '*',
+          'monthday'  => '*',
+          'month'     => '*',
+          'weekday'   => '*'
+        })}
+
+        it 'uses a computed max disable time to enable puppet in puppetagent_cron.sh' do
+          expected = Regexp.escape('if [[ ${pup_status} -ne 0 && $(( ${now} - ${filedate} )) -gt 16200')
+          is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/#{expected}/)
+        end
+      end
+
+      context 'with alternate minute_base' do
+        let(:params) {{ :minute_base => 'foo' }}
+        it { is_expected.to contain_cron('puppetagent').with({
+          'command'   => '/usr/local/bin/puppetagent_cron.sh',
+          'minute'    => [29,59],
+          'hour'      => '*',
+          'monthday'  => '*',
+          'month'     => '*',
+          'weekday'   => '*'
+        })}
+      end
+
+      context "with interval enabled" do
+        let(:params) {{ :minute => 'nil' }}
+        it { is_expected.to contain_cron('puppetagent').with({
+          'minute'    => '*/30',
+        })}
+
+        it 'uses a computed max disable time to enable puppet in puppetagent_cron.sh' do
+          expected = Regexp.escape('if [[ ${pup_status} -ne 0 && $(( ${now} - ${filedate} )) -gt 16200')
+          is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/#{expected}/)
+        end
+      end
+
+      context 'with specific cron parameters specified' do
+        let(:params) {{ 
+          :minute   => '1',
+          :hour     => '2',
+          :monthday => '3',
+          :month    => '4',
+          :weekday  => '5'
+        }}
+
+        it { is_expected.to contain_cron('puppetagent').with({
+          'command'   => '/usr/local/bin/puppetagent_cron.sh',
+          'minute'    => '1',
+          'hour'      => '2',
+          'monthday'  => '3',
+          'month'     => '4',
+          'weekday'   => '5'
+        })}
+      end
+
+      context 'with altername maxruntime' do
+        let(:params) {{ :maxruntime => 10 }}
+
+        it 'uses maxruntime to kill processes in puppetagent_cron.sh' do
+          expected = Regexp.escape('if [[ -n "${pup_status}" && $(( ${now} - ${filedate} )) -gt 600')
+          is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/#{expected}/)
+        end
+      end
+
+      context 'with break_puppet_lock disabled' do
+        let(:params) {{ :break_puppet_lock => false }}
+        it { is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/handles puppet processes which have been running longer than maxruntime/) }
+        it { is_expected.to_not contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/handles forcibly enabling puppet agent/) }
+      end
+
+
+      context 'with max_disable_time specified' do
+        let(:params) {{ :max_disable_time => 5 }}
+
+        it 'uses max_disable_time to enable puppet in puppetagent_cron.sh' do
+          expected = Regexp.escape('if [[ ${pup_status} -ne 0 && $(( ${now} - ${filedate} )) -gt 300')
+          is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/#{expected}/)
         end
       end
     end


### PR DESCRIPTION
Add SHA256-based option to generate the minute parameter for
a client's puppet agent cron from its IP address. This option
is intended mitigate the undesirable clustering of client puppet
agent runs, when the number of IPs to be transformed is less
than the minute range over which the randomization is requested
(60) and/or the client IPs are not linearly assigned.