### PR TITLE
(SIMP-3835) Fix `:selinux_config_mode` bug

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Oct 02 2017 Chris Tessmer <chris.tessmer@onyxpoint.com> - 7.4.1-0
+- Fixed bug where `:selinux_config_mode` is tested even when `:selinux` is
+  false.
+
 * Mon Sep 11 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 7.4.0-0
 - Add SHA256-based option to generate the minute parameter for
   a client's puppet agent cron from its IP address. This option

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -348,18 +348,16 @@ class pupmod (
     }
 
     # Changing SELinux booleans on a minor update is a horrible idea.
-    if ( $::operatingsystem in ['RedHat','CentOS'] ) and ( $::operatingsystemmajrelease < '7' ) {
+    if ( $facts['operatingsystem'] in ['RedHat','CentOS'] ) and ( $facts['operatingsystemmajrelease'] < '7' ) {
       $puppet_agent_sebool = 'puppet_manage_all_files'
     }
     else {
       $puppet_agent_sebool = 'puppetagent_manage_all_files'
     }
-    if $::selinux {
-      if $::selinux_current_mode and $::selinux_current_mode != 'disabled' {
-        selboolean { $puppet_agent_sebool :
-          persistent => true,
-          value      => 'on'
-        }
+    if $facts['selinux'] and $facts['selinux_current_mode'] and ($facts['selinux_current_mode'] != 'disabled') {
+      selboolean { $puppet_agent_sebool :
+        persistent => true,
+        value      => 'on'
       }
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -354,10 +354,12 @@ class pupmod (
     else {
       $puppet_agent_sebool = 'puppetagent_manage_all_files'
     }
-    if $::selinux_current_mode and $::selinux_current_mode != 'disabled' {
-      selboolean { $puppet_agent_sebool :
-        persistent => true,
-        value      => 'on'
+    if $::selinux {
+      if $::selinux_current_mode and $::selinux_current_mode != 'disabled' {
+        selboolean { $puppet_agent_sebool :
+          persistent => true,
+          value      => 'on'
+        }
       }
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pupmod",
-  "version": "7.4.0",
+  "version": "7.4.1",
   "author": "SIMP Team",
   "summary": "A puppet module to manage puppetserver and puppet agents",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -147,7 +147,6 @@ describe 'pupmod' do
             context 'with_selinux_disabled' do
               let(:facts) {
                 _facts = @extras.merge(os_facts)
-                _facts[:selinux_current_mode] = 'disabled'
                 _facts[:selinux] = false
 
                 _facts


### PR DESCRIPTION
This commit fixes an issue discovered when testing `poss` scenario
against non-SIMP factsets where the compile will fail because
`:selinux_config_mode` does not exist when `:selinux` is `false`.

SIMP-3835 #close