### PR TITLE
(SIMP-4508) pupmod: Allow tweaking of auth allow/deny

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,13 @@
-* Fri Feb 09 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 7.4.2-0
-- Add the missing puppetlabs/inifile dependency to the metadata.json
-- Fixed puppet lint problem
+* Tue Mar 06 2018 Nick Miller <nick.miller@onyxpoint.com> - 7.4.2-0
 - pupmod::master::simp_auth
   - Allow tweaking `allow` and `deny` rules for supported keydist auth rules
   - Removed Mcollective auth rules
-  - changed `$pki_cacerts_all`'s auth rule from `*` to `certname`
+  - Changed `$pki_cacerts_all`'s auth rule from `*` to `certname`
+  - Deprecated `$legacy_cacerts_all` and `$legacy_pki_keytabs_from_host`
+
+* Fri Feb 09 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 7.4.2-0
+- Add the missing puppetlabs/inifile dependency to the metadata.json
+- Fixed puppet lint problem
 
 * Mon Oct 02 2017 Chris Tessmer <chris.tessmer@onyxpoint.com> - 7.4.1-0
 - Fixed bug where `:selinux_config_mode` is tested even when `:selinux` is

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 * Fri Feb 09 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 7.4.2-0
 - Add the missing puppetlabs/inifile dependency to the metadata.json
 - Fixed puppet lint problem
+- pupmod::master::simp_auth
+  - Allow tweaking `allow` and `deny` rules for supported keydist auth rules
+  - Removed Mcollective auth rules
+  - changed `$pki_cacerts_all`'s auth rule from `*` to `certname`
 
 * Mon Oct 02 2017 Chris Tessmer <chris.tessmer@onyxpoint.com> - 7.4.1-0
 - Fixed bug where `:selinux_config_mode` is tested even when `:selinux` is

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -57,7 +57,7 @@
 #   The protocols that are allowed for communication with the Puppet Server. See
 #   the ssl-protocols documentaiton for the Puppet Server for additional details.
 #
-# @param ssl_cipher_suite
+# @param ssl_cipher_suites
 #   The allowed SSL Cipher Suites to be used by the Puppet Server. The allowed
 #   list is Java version dependent and you will need to check the system Java
 #   documentaiton for details.

--- a/manifests/master/simp_auth.pp
+++ b/manifests/master/simp_auth.pp
@@ -1,7 +1,7 @@
 # Add SIMP-specific entries to PuppetServer's auth.conf
 #
 # For documentation about *_allow and *_deny, see the puppetserver docs
-# @see https://puppet.com/docs/puppetserver/5.2/config_file_auth.html#allow-allow-unauthenticated-and-deny
+# @see https://puppet.com/docs/puppetserver/2.7/config_file_auth.html#rules
 #
 # @param server_distribution Puppet open source or PE
 #
@@ -21,13 +21,17 @@
 #
 # @param keydist_from_host
 #   If enabled, allow access to each host's own certs from the `pki_files` module
-# @param keydist_from_host_allow
-# @param keydist_from_host_deny
+# @param keydist_from_host_allow Rules that the puppetserver should allow
+#   @see https://puppet.com/docs/puppetserver/2.7/config_file_auth.html#rules
+# @param keydist_from_host_deny Rules that the puppetserver should deny
+#   @see https://puppet.com/docs/puppetserver/2.7/config_file_auth.html#rules
 #
 # @param krb5_keytabs_from_host
 #   If enabled, allow access to each host's own kerberos keytabs from the `pki_files` module
-# @param krb5_keytabs_from_host_allow
-# @param krb5_keytabs_from_host_deny
+# @param krb5_keytabs_from_host_allow Rules that the puppetserver should allow
+#   @see https://puppet.com/docs/puppetserver/2.7/config_file_auth.html#rules
+# @param krb5_keytabs_from_host_deny Rules that the puppetserver should deny
+#   @see https://puppet.com/docs/puppetserver/2.7/config_file_auth.html#rules
 #
 class pupmod::master::simp_auth (
   Simplib::ServerDistribution $server_distribution          = simplib::lookup('simp_options::puppet::server_distribution', { 'default_value' => 'PC1' } ),
@@ -54,6 +58,13 @@ class pupmod::master::simp_auth (
   $bool2ensure = {
     true  => 'present',
     false => 'absent'
+  }
+
+  if $legacy_cacerts_all {
+    simplib::deprecation('pupmod::master::simp_auth::legacy_cacerts_all', 'pupmod::master::simp_auth::legacy_cacerts_all is deprecated and will be removed in a future version')
+  }
+  if $legacy_pki_keytabs_from_host {
+    simplib::deprecation('pupmod::master::simp_auth::legacy_pki_keytabs_from_host', 'pupmod::master::simp_auth::legacy_pki_keytabs_from_host is deprecated and will be removed in a future version')
   }
 
   puppet_authorization::rule { 'Allow access to the PKI cacerts from the legacy pki module from all hosts':

--- a/manifests/master/simp_auth.pp
+++ b/manifests/master/simp_auth.pp
@@ -11,8 +11,16 @@
 # @param legacy_cacerts_all
 #   If enabled, allow access to the PKI cacerts from the legacy `pki` module from all hosts
 #
+# @param legacy_mcollective_all
+#   If enabled, allow access to the mcollective cacerts from the legacy `pki` module from all hosts
+#
 # @param legacy_pki_keytabs_from_host
 #   If enabled, allow access to each host's own kerberos keytabs from the legacy location
+#
+# @param pki_mcollective_all
+#   Type:    Boolean
+#   Default: true
+#   If enabled, allow access to the mcollective PKI from the `pki_files` module from all hosts
 #
 # @param pki_cacerts_all
 #   If enabled, allow access to the cacerts from the `pki_files` module from all hosts

--- a/manifests/master/simp_auth.pp
+++ b/manifests/master/simp_auth.pp
@@ -1,55 +1,48 @@
 # Add SIMP-specific entries to PuppetServer's auth.conf
 #
+# For documentation about *_allow and *_deny, see the puppetserver docs
+# @see https://puppet.com/docs/puppetserver/5.2/config_file_auth.html#allow-allow-unauthenticated-and-deny
+#
+# @param server_distribution Puppet open source or PE
+#
 # @param auth_conf_path
-#   Type:    Stdlib::AbsolutePath
-#   Default: /etc/puppetlabs/puppetserver/conf.d/auth.conf
 #   The location to the puppet master's auth.conf
 #
 # @param legacy_cacerts_all
-#   Type:    Boolean
-#   Default: true
 #   If enabled, allow access to the PKI cacerts from the legacy `pki` module from all hosts
 #
-# @param legacy_mcollective_all
-#   Type:    Boolean
-#   Default: true
-#   If enabled, allow access to the mcollective cacerts from the legacy `pki` module from all hosts
-#
 # @param legacy_pki_keytabs_from_host
-#   Type:    Boolean
-#   Default: true
 #   If enabled, allow access to each host's own kerberos keytabs from the legacy location
 #
 # @param pki_cacerts_all
-#   Type:    Boolean
-#   Default: true
 #   If enabled, allow access to the cacerts from the `pki_files` module from all hosts
-#
-# @param pki_mcollective_all
-#   Type:    Boolean
-#   Default: true
-#   If enabled, allow access to the mcollective PKI from the `pki_files` module from all hosts
+# @param pki_cacerts_all_allow
+# @param pki_cacerts_all_deny
 #
 # @param keydist_from_host
-#   Type:    Boolean
-#   Default: true
 #   If enabled, allow access to each host's own certs from the `pki_files` module
+# @param keydist_from_host_allow
+# @param keydist_from_host_deny
 #
 # @param krb5_keytabs_from_host
-#   Type:    Boolean
-#   Default: true
 #   If enabled, allow access to each host's own kerberos keytabs from the `pki_files` module
+# @param krb5_keytabs_from_host_allow
+# @param krb5_keytabs_from_host_deny
 #
 class pupmod::master::simp_auth (
   Simplib::ServerDistribution $server_distribution          = simplib::lookup('simp_options::puppet::server_distribution', { 'default_value' => 'PC1' } ),
   Stdlib::AbsolutePath        $auth_conf_path               = '/etc/puppetlabs/puppetserver/conf.d/auth.conf',
   Boolean                     $legacy_cacerts_all           = false,
-  Boolean                     $legacy_mcollective_all       = false,
   Boolean                     $legacy_pki_keytabs_from_host = false,
   Boolean                     $pki_cacerts_all              = true,
-  Boolean                     $pki_mcollective_all          = true,
+  NotUndef                    $pki_cacerts_all_allow        = 'certname',
+  Any                         $pki_cacerts_all_deny         = undef,
   Boolean                     $keydist_from_host            = true,
+  NotUndef                    $keydist_from_host_allow      = '$2',
+  Any                         $keydist_from_host_deny       = undef,
   Boolean                     $krb5_keytabs_from_host       = true,
+  NotUndef                    $krb5_keytabs_from_host_allow = '$2',
+  Any                         $krb5_keytabs_from_host_deny  = undef,
 ) {
 
   $_master_service = $server_distribution ? {
@@ -74,17 +67,6 @@ class pupmod::master::simp_auth (
     notify               => Service[$_master_service],
   }
 
-  puppet_authorization::rule { 'Allow access to the mcollective cacerts from the legacy pki module from all hosts':
-    ensure               => $bool2ensure[$legacy_mcollective_all],
-    match_request_path   => '^/puppet/v3/file_(metadata|content)/modules/pki/keydist/mcollective',
-    match_request_type   => 'regex',
-    match_request_method => ['get'],
-    allow                => '*',
-    sort_order           => 420,
-    path                 => $auth_conf_path,
-    notify               => Service[$_master_service],
-  }
-
   puppet_authorization::rule { 'Allow access to each hosts own kerberos keytabs from the legacy location':
     ensure               => $bool2ensure[$legacy_pki_keytabs_from_host],
     match_request_path   => '^/puppet/v3/file_(metadata|content)/modules/pki_files/keytabs/([^/]+)',
@@ -101,19 +83,9 @@ class pupmod::master::simp_auth (
     match_request_path   => '^/puppet/v3/file_(metadata|content)/modules/pki_files/keydist/cacerts',
     match_request_type   => 'regex',
     match_request_method => ['get'],
-    allow                => '*',
+    allow                => $pki_cacerts_all_allow,
+    deny                 => $pki_cacerts_all_deny,
     sort_order           => 410,
-    path                 => $auth_conf_path,
-    notify               => Service[$_master_service],
-  }
-
-  puppet_authorization::rule { 'Allow access to the mcollective PKI from the pki_files module from all hosts':
-    ensure               => $bool2ensure[$pki_mcollective_all],
-    match_request_path   => '^/puppet/v3/file_(metadata|content)/modules/pki_files/keydist/mcollective',
-    match_request_type   => 'regex',
-    match_request_method => ['get'],
-    allow                => '*',
-    sort_order           => 430,
     path                 => $auth_conf_path,
     notify               => Service[$_master_service],
   }
@@ -123,7 +95,8 @@ class pupmod::master::simp_auth (
     match_request_path   => '^/puppet/v3/file_(metadata|content)/modules/pki_files/keydist/([^/]+)',
     match_request_type   => 'regex',
     match_request_method => ['get'],
-    allow                => '$2',
+    allow                => $keydist_from_host_allow,
+    deny                 => $keydist_from_host_deny,
     sort_order           => 440,
     path                 => $auth_conf_path,
     notify               => Service[$_master_service],
@@ -134,7 +107,8 @@ class pupmod::master::simp_auth (
     match_request_path   => '^/puppet/v3/file_(metadata|content)/modules/krb5_files/keytabs/([^/]+)',
     match_request_type   => 'regex',
     match_request_method => ['get'],
-    allow                => '$2',
+    allow                => $krb5_keytabs_from_host_allow,
+    deny                 => $krb5_keytabs_from_host_deny,
     sort_order           => 460,
     path                 => $auth_conf_path,
     notify               => Service[$_master_service],

--- a/manifests/master/simp_auth.pp
+++ b/manifests/master/simp_auth.pp
@@ -16,11 +16,17 @@
 #
 # @param pki_cacerts_all
 #   If enabled, allow access to the cacerts from the `pki_files` module from all hosts
+# @param pki_cacerts_all_rule
+#   The regex rule to match requests against. The provided rule matched requests
+#   coming from the `files/keydist/cacerts` directory from the pki_files module
 # @param pki_cacerts_all_allow
 # @param pki_cacerts_all_deny
 #
 # @param keydist_from_host
 #   If enabled, allow access to each host's own certs from the `pki_files` module
+# @param keydist_from_host_rule
+#   The regex rule to match requests against. The provided rule matched requests
+#   coming from the `files/keydist` directory from the pki_files module
 # @param keydist_from_host_allow Rules that the puppetserver should allow
 #   @see https://puppet.com/docs/puppetserver/2.7/config_file_auth.html#rules
 # @param keydist_from_host_deny Rules that the puppetserver should deny
@@ -28,6 +34,9 @@
 #
 # @param krb5_keytabs_from_host
 #   If enabled, allow access to each host's own kerberos keytabs from the `pki_files` module
+# @param krb5_keytabs_from_host_rule
+#   The regex rule to match requests against. The provided rule matched requests
+#   coming from the `files/keytabs` directory from the krb5_files module
 # @param krb5_keytabs_from_host_allow Rules that the puppetserver should allow
 #   @see https://puppet.com/docs/puppetserver/2.7/config_file_auth.html#rules
 # @param krb5_keytabs_from_host_deny Rules that the puppetserver should deny
@@ -39,12 +48,15 @@ class pupmod::master::simp_auth (
   Boolean                     $legacy_cacerts_all           = false,
   Boolean                     $legacy_pki_keytabs_from_host = false,
   Boolean                     $pki_cacerts_all              = true,
+  NotUndef                    $pki_cacerts_all_rule         = '^/puppet/v3/file_(metadata|content)/modules/pki_files/keydist/cacerts',
   NotUndef                    $pki_cacerts_all_allow        = 'certname',
   Any                         $pki_cacerts_all_deny         = undef,
   Boolean                     $keydist_from_host            = true,
+  NotUndef                    $keydist_from_host_rule       = '^/puppet/v3/file_(metadata|content)/modules/pki_files/keydist/([^/]+)',
   NotUndef                    $keydist_from_host_allow      = '$2',
   Any                         $keydist_from_host_deny       = undef,
   Boolean                     $krb5_keytabs_from_host       = true,
+  NotUndef                    $krb5_keytabs_from_host_rule  = '^/puppet/v3/file_(metadata|content)/modules/krb5_files/keytabs/([^/]+)',
   NotUndef                    $krb5_keytabs_from_host_allow = '$2',
   Any                         $krb5_keytabs_from_host_deny  = undef,
 ) {
@@ -91,7 +103,7 @@ class pupmod::master::simp_auth (
 
   puppet_authorization::rule { 'Allow access to the cacerts from the pki_files module from all hosts':
     ensure               => $bool2ensure[$pki_cacerts_all],
-    match_request_path   => '^/puppet/v3/file_(metadata|content)/modules/pki_files/keydist/cacerts',
+    match_request_path   => $pki_cacerts_all_rule,
     match_request_type   => 'regex',
     match_request_method => ['get'],
     allow                => $pki_cacerts_all_allow,
@@ -103,7 +115,7 @@ class pupmod::master::simp_auth (
 
   puppet_authorization::rule { 'Allow access to each hosts own certs from the pki_files module':
     ensure               => $bool2ensure[$keydist_from_host],
-    match_request_path   => '^/puppet/v3/file_(metadata|content)/modules/pki_files/keydist/([^/]+)',
+    match_request_path   => $keydist_from_host_rule,
     match_request_type   => 'regex',
     match_request_method => ['get'],
     allow                => $keydist_from_host_allow,
@@ -115,7 +127,7 @@ class pupmod::master::simp_auth (
 
   puppet_authorization::rule { 'Allow access to each hosts own kerberos keytabs from the krb5_files module':
     ensure               => $bool2ensure[$krb5_keytabs_from_host],
-    match_request_path   => '^/puppet/v3/file_(metadata|content)/modules/krb5_files/keytabs/([^/]+)',
+    match_request_path   => $krb5_keytabs_from_host_rule,
     match_request_type   => 'regex',
     match_request_method => ['get'],
     allow                => $krb5_keytabs_from_host_allow,

--- a/spec/classes/master/simp_auth_spec.rb
+++ b/spec/classes/master/simp_auth_spec.rb
@@ -22,24 +22,8 @@ describe 'pupmod::master::simp_auth' do
           'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/pki_files/keydist/cacerts',
           'match_request_type'   => 'regex',
           'match_request_method' => ['get'],
-          'allow'                => '*',
+          'allow'                => 'certname',
           'sort_order'           => 410,
-        }) }
-        it { is_expected.to create_puppet_authorization__rule('Allow access to the mcollective cacerts from the legacy pki module from all hosts').with({
-          'ensure'               => 'absent',
-          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/pki/keydist/mcollective',
-          'match_request_type'   => 'regex',
-          'match_request_method' => ['get'],
-          'allow'                => '*',
-          'sort_order'           => 420,
-        }) }
-        it { is_expected.to create_puppet_authorization__rule('Allow access to the mcollective PKI from the pki_files module from all hosts').with({
-          'ensure'               => 'present',
-          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/pki_files/keydist/mcollective',
-          'match_request_type'   => 'regex',
-          'match_request_method' => ['get'],
-          'allow'                => '*',
-          'sort_order'           => 430,
         }) }
         it { is_expected.to create_puppet_authorization__rule('Allow access to each hosts own certs from the pki_files module').with({
           'ensure'               => 'present',

--- a/spec/classes/master/simp_auth_spec.rb
+++ b/spec/classes/master/simp_auth_spec.rb
@@ -25,6 +25,22 @@ describe 'pupmod::master::simp_auth' do
           'allow'                => 'certname',
           'sort_order'           => 410,
         }) }
+        it { is_expected.to create_puppet_authorization__rule('Allow access to the mcollective cacerts from the legacy pki module from all hosts').with({
+          'ensure'               => 'absent',
+          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/pki/keydist/mcollective',
+          'match_request_type'   => 'regex',
+          'match_request_method' => ['get'],
+          'allow'                => '*',
+          'sort_order'           => 420,
+        }) }
+        it { is_expected.to create_puppet_authorization__rule('Allow access to the mcollective PKI from the pki_files module from all hosts').with({
+          'ensure'               => 'present',
+          'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/pki_files/keydist/mcollective',
+          'match_request_type'   => 'regex',
+          'match_request_method' => ['get'],
+          'allow'                => '*',
+          'sort_order'           => 430,
+        }) }
         it { is_expected.to create_puppet_authorization__rule('Allow access to each hosts own certs from the pki_files module').with({
           'ensure'               => 'present',
           'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/pki_files/keydist/([^/]+)',


### PR DESCRIPTION
- pupmod::master::simp_auth
  - Allow tweaking `allow` and `deny` rules for supported keydist auth rules

SIMP-4508 #close