### PR TITLE
(SIMP-4574) Make the master service name dynamic

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 - Fix service name and related resources on Puppet Enterprise (PE)
   - Fix `$tmpdir` setting on PE
   - Fix Puppetserver service management on PE
+- Remove support for Oracle Enterprise Linux, which was added prematurely.
 
 * Tue Mar 06 2018 Nick Miller <nick.miller@onyxpoint.com> - 7.5.0-0
 - pupmod::master::simp_auth

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Mon Mar 19 2018 Lucas Yamanishi <lucas.yamanishi@onyxpoint.com> - 7.5.1-0
+- Fix service name and related resources on Puppet Enterprise (PE)
+  - Fix `$tmpdir` setting on PE
+  - Fix Puppetserver service management on PE
+
 * Tue Mar 06 2018 Nick Miller <nick.miller@onyxpoint.com> - 7.5.0-0
 - pupmod::master::simp_auth
   - Allow tweaking `allow` and `deny` rules for supported keydist auth rules

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -238,7 +238,11 @@ class pupmod::master (
   $_server_version = pupmod::server_version()
 
   if ($mock == false) {
-    $service = 'puppetserver'
+    $service = $server_distribution ? {
+      'PE'    => 'pe-puppetserver',
+      default => 'puppetserver',
+    }
+
     include '::pupmod'
     class { '::pupmod::master::sysconfig':
       service => $service,

--- a/metadata.json
+++ b/metadata.json
@@ -78,13 +78,6 @@
         "6",
         "7"
       ]
-    },
-    {
-      "operatingsystem": "OracleLinux",
-      "operatingsystemrelease": [
-        "6",
-        "7"
-      ]
     }
   ],
   "data_provider": "hiera"

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pupmod",
-  "version": "7.5.0",
+  "version": "7.5.1",
   "author": "SIMP Team",
   "summary": "A puppet module to manage puppetserver and puppet agents",
   "license": "Apache-2.0",
@@ -27,7 +27,7 @@
     },
     {
       "name": "puppetlabs/inifile",
-      "version_requirement": ">= 1.6.0 < 3.0.0" 
+      "version_requirement": ">= 1.6.0 < 3.0.0"
     },
     {
       "name": "puppetlabs/puppet_authorization",

--- a/spec/classes/master/sysconfig_spec.rb
+++ b/spec/classes/master/sysconfig_spec.rb
@@ -38,7 +38,12 @@ describe 'pupmod::master::sysconfig' do
               )
             }
 
-            it { is_expected.to contain_pe_ini_subsetting('pupmod::master::sysconfig::javatempdir').with_value(%r{/pserver_tmp$}) }
+            it 'sets $tmpdir via a pe_ini_subsetting resource' do
+              expect(catalogue).to contain_pe_ini_subsetting('pupmod::master::sysconfig::javatempdir').with(
+                'value' => %r{/pserver_tmp$},
+                'path'  => '/etc/sysconfig/pe-puppetserver',
+              )
+            end
           else
             let(:facts){ @extras.merge(os_facts).merge(:memorysize_mb => '490.16') }
 

--- a/spec/classes/master_spec.rb
+++ b/spec/classes/master_spec.rb
@@ -377,6 +377,20 @@ describe 'pupmod::master' do
         end
 
         describe "with non-default parameters" do
+          context 'when server_distribution => PE' do
+            let(:params) {{:server_distribution => 'PE'}}
+
+            it { is_expected.to contain_service('pe-puppetserver') }
+            it { is_expected.not_to contain_service('puppetserver') }
+          end
+
+          context 'when server_distribution => PC1' do
+            let(:params) {{:server_distribution => 'PC1'}}
+
+            it { is_expected.to contain_service('puppetserver') }
+            it { is_expected.not_to contain_service('pe-puppetserver') }
+          end
+
           context 'with enable_ca => false' do
             let(:params) {{:enable_ca => false}}
 


### PR DESCRIPTION
Prior to this the service name for the Puppetserver was hard-coded to
the open source name, `puppetserver`.  Puppet Enterprise uses a
different name, however, so any resources that used that variable were
wrong.  This commit changes the variable assignment to use a selector
based on the parameter `pupmod::master::server_distribution`.