### PR TITLE
Fix Puppet 5 spec tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -23,6 +23,7 @@ fixtures:
     rsyslog: https://github.com/simp/pupmod-simp-rsyslog
     simpcat: https://github.com/simp/pupmod-simp-simpcat
     simplib: https://github.com/simp/pupmod-simp-simplib
+    simp_options: https://github.com/simp/pupmod-simp-simp_options
     stdlib: https://github.com/simp/puppetlabs-stdlib
     puppet_enterprise:
       repo: https://github.com/simp/pupmod-mock-puppet_enterprise

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,6 @@ before_install:
   - rm -f Gemfile.lock
 
 jobs:
-  allow_failures:
-    - env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
-
   include:
     - stage: check
       rvm: 2.4.1

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,8 +2,8 @@
 - Fix service name and related resources on Puppet Enterprise (PE)
   - Fix `$tmpdir` setting on PE
   - Fix Puppetserver service management on PE
-- Remove support for Oracle Enterprise Linux
 - Fix default for pupmod::master::simp_auth::pki_cacerts_all_allow
+  - `certname` back to `*`
 
 * Tue Mar 06 2018 Nick Miller <nick.miller@onyxpoint.com> - 7.5.0-0
 - pupmod::master::simp_auth

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
-* Mon Mar 19 2018 Lucas Yamanishi <lucas.yamanishi@onyxpoint.com> - 7.5.1-0
+* Mon Mar 19 2018 Lucas Yamanishi <lucas.yamanishi@onyxpoint.com> - 7.5.0-0
 - Fix service name and related resources on Puppet Enterprise (PE)
   - Fix `$tmpdir` setting on PE
   - Fix Puppetserver service management on PE
-- Remove support for Oracle Enterprise Linux, which was added prematurely.
+- Remove support for Oracle Enterprise Linux
 
 * Tue Mar 06 2018 Nick Miller <nick.miller@onyxpoint.com> - 7.5.0-0
 - pupmod::master::simp_auth

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,14 +2,11 @@
 - Fix service name and related resources on Puppet Enterprise (PE)
   - Fix `$tmpdir` setting on PE
   - Fix Puppetserver service management on PE
-- Fix default for pupmod::master::simp_auth::pki_cacerts_all_allow
-  - `certname` back to `*`
 
 * Tue Mar 06 2018 Nick Miller <nick.miller@onyxpoint.com> - 7.5.0-0
 - pupmod::master::simp_auth
   - Allow tweaking `allow` and `deny` rules for supported keydist auth rules
   - Removed Mcollective auth rules
-  - Changed `$pki_cacerts_all`'s auth rule from `*` to `certname`
   - Deprecated `$legacy_cacerts_all` and `$legacy_pki_keytabs_from_host`
 
 * Fri Mar 02 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.5.0-0

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
   - Fix `$tmpdir` setting on PE
   - Fix Puppetserver service management on PE
 - Remove support for Oracle Enterprise Linux
+- Fix default for pupmod::master::simp_auth::pki_cacerts_all_allow
 
 * Tue Mar 06 2018 Nick Miller <nick.miller@onyxpoint.com> - 7.5.0-0
 - pupmod::master::simp_auth

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :development do
   gem 'puppet-blacksmith'
   gem 'guard-rake'
   gem 'pry'
+  gem 'pry-byebug'
   gem 'pry-doc'
 
   # `listen` is a dependency of `guard`
@@ -37,5 +38,5 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.7')
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.10')
 end

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ group :test do
   gem 'puppet-strings'
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
-  gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 2.0')
+  gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 2.0.0')
   gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.2', '< 6.0'])
 end
 

--- a/manifests/master/base.pp
+++ b/manifests/master/base.pp
@@ -79,6 +79,6 @@ class pupmod::master::base {
     membership => 'inclusive',
     shell      => '/sbin/nologin',
     tag        => 'firstrun',
-    require    => Package['puppetserver']
+    require    => Package[$::pupmod::master::service]
   }
 }

--- a/manifests/master/simp_auth.pp
+++ b/manifests/master/simp_auth.pp
@@ -64,7 +64,7 @@ class pupmod::master::simp_auth (
   Boolean                     $pki_mcollective_all          = true,
   Boolean                     $pki_cacerts_all              = true,
   NotUndef                    $pki_cacerts_all_rule         = '^/puppet/v3/file_(metadata|content)/modules/pki_files/keydist/cacerts',
-  NotUndef                    $pki_cacerts_all_allow        = 'certname',
+  NotUndef                    $pki_cacerts_all_allow        = '*',
   Any                         $pki_cacerts_all_deny         = undef,
   Boolean                     $keydist_from_host            = true,
   NotUndef                    $keydist_from_host_rule       = '^/puppet/v3/file_(metadata|content)/modules/pki_files/keydist/([^/]+)',

--- a/metadata.json
+++ b/metadata.json
@@ -78,6 +78,13 @@
         "6",
         "7"
       ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
     }
   ],
   "data_provider": "hiera"

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pupmod",
-  "version": "7.5.1",
+  "version": "7.5.0",
   "author": "SIMP Team",
   "summary": "A puppet module to manage puppetserver and puppet agents",
   "license": "Apache-2.0",

--- a/spec/classes/master/simp_auth_spec.rb
+++ b/spec/classes/master/simp_auth_spec.rb
@@ -40,7 +40,7 @@ describe 'pupmod::master::simp_auth' do
             'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/pki_files/keydist/cacerts',
             'match_request_type'   => 'regex',
             'match_request_method' => ['get'],
-            'allow'                => 'certname',
+            'allow'                => '*',
             'sort_order'           => 410,
           }) }
           it { is_expected.to create_puppet_authorization__rule('Allow access to the mcollective cacerts from the legacy pki module from all hosts').with({

--- a/spec/classes/master_spec.rb
+++ b/spec/classes/master_spec.rb
@@ -652,4 +652,3 @@ describe 'pupmod::master' do
     end
   end
 end
-

--- a/spec/classes/master_spec.rb
+++ b/spec/classes/master_spec.rb
@@ -378,7 +378,7 @@ describe 'pupmod::master' do
 
         describe "with non-default parameters" do
           context 'when server_distribution => PE' do
-            let(:params) {{:server_distribution => 'PE'}}
+            let(:hieradata) { 'pe' }
 
             it { is_expected.to contain_service('pe-puppetserver') }
             it { is_expected.not_to contain_service('puppetserver') }

--- a/spec/fixtures/hieradata/default.yaml
+++ b/spec/fixtures/hieradata/default.yaml
@@ -1,5 +1,0 @@
----
-pupmod::puppet_server: '1.2.3.4'
-apache::rsync_server: '127.0.0.1'
-apache::ssl::client_nets: '127.0.0.1/32'
-use_fips: true

--- a/spec/fixtures/hieradata/pe.yaml
+++ b/spec/fixtures/hieradata/pe.yaml
@@ -1,0 +1,8 @@
+---
+simp_options::puppet::server: "%{facts.fqdn}"
+simp_options::puppet::ca: "%{facts.fqdn}"
+simp_options::puppet::server_distribution: 'PE'
+pupmod::puppet_server: '1.2.3.4'
+apache::rsync_server: '127.0.0.1'
+apache::ssl::client_nets: '127.0.0.1/32'
+use_fips: true

--- a/spec/fixtures/hieradata/pe.yaml
+++ b/spec/fixtures/hieradata/pe.yaml
@@ -1,8 +1,2 @@
 ---
-simp_options::puppet::server: "%{facts.fqdn}"
-simp_options::puppet::ca: "%{facts.fqdn}"
 simp_options::puppet::server_distribution: 'PE'
-pupmod::puppet_server: '1.2.3.4'
-apache::rsync_server: '127.0.0.1'
-apache::ssl::client_nets: '127.0.0.1/32'
-use_fips: true

--- a/spec/fixtures/hieradata/pupmod_splay_is_true.yaml
+++ b/spec/fixtures/hieradata/pupmod_splay_is_true.yaml
@@ -1,3 +1,0 @@
----
-pupmod::splay: true
-pupmod::splaylimit: 1800

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,13 @@ if !ENV.key?( 'TRUSTED_NODE_DATA' )
   ENV['TRUSTED_NODE_DATA']='yes'
 end
 
+
+if ENV['PUPPET_DEBUG']
+  Puppet::Util::Log.level = :debug
+  Puppet::Util::Log.newdestination(:console)
+end
+
+
 default_hiera_config =<<-EOM
 ---
 :backends:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,21 +22,16 @@ if !ENV.key?( 'TRUSTED_NODE_DATA' )
   ENV['TRUSTED_NODE_DATA']='yes'
 end
 
-
-if ENV['PUPPET_DEBUG']
-  Puppet::Util::Log.level = :debug
-  Puppet::Util::Log.newdestination(:console)
-end
-
-
 default_hiera_config =<<-EOM
 ---
 :backends:
+  - "rspec"
   - "yaml"
 :yaml:
   :datadir: "stub"
 :hierarchy:
   - "%{custom_hiera}"
+  - "%{spec_title}"
   - "%{module_name}"
   - "default"
 EOM
@@ -52,7 +47,7 @@ EOM
 # end
 #
 def set_environment(environment = :production)
-  RSpec.configure { |c| c.default_facts['environment'] = environment.to_s }
+    RSpec.configure { |c| c.default_facts['environment'] = environment.to_s }
 end
 
 # This can be used from inside your spec tests to load custom hieradata within
@@ -74,7 +69,7 @@ end
 #
 # Note: Any colons (:) are replaced with underscores (_) in the class name.
 def set_hieradata(hieradata)
-  RSpec.configure { |c| c.default_facts['custom_hiera'] = hieradata }
+    RSpec.configure { |c| c.default_facts['custom_hiera'] = hieradata }
 end
 
 if not File.directory?(File.join(fixture_path,'hieradata')) then
@@ -149,9 +144,6 @@ RSpec.configure do |c|
     # clean up the mocked environmentpath
     FileUtils.rm_rf(@spec_global_env_temp)
     @spec_global_env_temp = nil
-  end
-  c.after(:suite) do
-#    RSpec::Puppet::Coverage.report!(100)
   end
 end
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -28,20 +28,12 @@ RSpec.configure do |c|
     begin
       # Install modules and dependencies from spec/fixtures/modules
       copy_fixture_modules_to( hosts )
-      begin
-        server = only_host_with_role(hosts, 'server')
-      rescue ArgumentError =>e
-        server = only_host_with_role(hosts, 'default')
-      end
 
       # Generate and install PKI certificates on each SUT
       Dir.mktmpdir do |cert_dir|
-        run_fake_pki_ca_on(server, hosts, cert_dir )
+        run_fake_pki_ca_on( default, hosts, cert_dir )
         hosts.each{ |sut| copy_pki_to( sut, cert_dir, '/etc/pki/simp-testing' )}
       end
-
-      # add PKI keys
-      copy_keydist_to(server)
     rescue StandardError, ScriptError => e
       if ENV['PRY']
         require 'pry'; binding.pry


### PR DESCRIPTION
- Fix service name and related resources on Puppet Enterprise (PE)
  - Fix `$tmpdir` setting on PE
  - Fix Puppetserver service management on PE
- Fix default for pupmod::master::simp_auth::pki_cacerts_all_allow
  - `certname` back to `*`
