### PR TITLE
(SIMP-4662) Disable puppet service if in cron mode

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Tue Apr 17 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 7.6.0-0
+- Added line in puppet cron to shutdown/disable puppet client service.
+- Added check in agent/cron manifest to disable and stop puppet client service
+  so it would not run multiple times on newly kickstarted systems.
+
 * Mon Mar 19 2018 Lucas Yamanishi <lucas.yamanishi@onyxpoint.com> - 7.5.0-0
 - Fix service name and related resources on Puppet Enterprise (PE)
   - Fix `$tmpdir` setting on PE

--- a/lib/facter/puppet_service_enabled.rb
+++ b/lib/facter/puppet_service_enabled.rb
@@ -1,0 +1,13 @@
+#
+# Determine if the puppet service is enabled.
+#
+Facter.add(:puppet_service_enabled) do
+  confine  :kernel => 'linux'
+  setcode do
+    if Facter.value(:service_provider) == 'systemd'
+      Facter::Core::Execution.execute('/usr/bin/systemctl is-enabled puppet.service').include? "enabled"
+    else
+      Facter::Core::Execution.execute('/sbin/chkconfig --list | grep -w puppet').include? ":on"
+    end
+  end
+end

--- a/lib/facter/puppet_service_enabled.rb
+++ b/lib/facter/puppet_service_enabled.rb
@@ -4,7 +4,7 @@
 Facter.add(:puppet_service_enabled) do
   confine  :kernel => 'linux'
   setcode do
-    if Facter.value(:service_provider) == 'systemd'
+    if Facter.value(:init_systems).include? "systemd"
       Facter::Core::Execution.execute('/usr/bin/systemctl is-enabled puppet.service').include? "enabled"
     else
       Facter::Core::Execution.execute('/sbin/chkconfig --list | grep -w puppet').include? ":on"

--- a/lib/facter/puppet_service_started.rb
+++ b/lib/facter/puppet_service_started.rb
@@ -4,7 +4,7 @@
 Facter.add(:puppet_service_started) do
   confine  :kernel => 'linux'
   setcode do
-    if Facter.value(:service_provider) == 'systemd'
+    if Facter.value(:init_systems).include? "systemd"
       Facter::Core::Execution.execute('/usr/bin/systemctl status puppet.service').include? "active (running)"
     else
       Facter::Core::Execution.execute('/sbin/service puppet status').include? "running"

--- a/lib/facter/puppet_service_started.rb
+++ b/lib/facter/puppet_service_started.rb
@@ -1,0 +1,13 @@
+#
+# Determine if the puppet service is started.
+#
+Facter.add(:puppet_service_started) do
+  confine  :kernel => 'linux'
+  setcode do
+    if Facter.value(:service_provider) == 'systemd'
+      Facter::Core::Execution.execute('/usr/bin/systemctl status puppet.service').include? "active (running)"
+    else
+      Facter::Core::Execution.execute('/sbin/service puppet status').include? "running"
+    end
+  end
+end

--- a/manifests/agent/cron.pp
+++ b/manifests/agent/cron.pp
@@ -202,4 +202,19 @@ class pupmod::agent::cron (
     mode    => '0750',
     content => epp("${module_name}/usr/local/bin/puppetagent_cron")
   }
+
+  file { '/usr/local/bin/careful_puppet_service_shutdown.sh':
+    ensure  => 'file',
+    mode    => '0750',
+    owner   => 'root',
+    group   => 'root',
+    content => epp("${module_name}/usr/local/bin/careful_puppet_service_shutdown")
+  }
+
+  if $facts['puppet_service_enabled'] or $facts['puppet_service_started'] {
+    exec { 'careful_puppet_service_shutdown':
+      command => '/usr/local/bin/careful_puppet_service_shutdown.sh &',
+      require => File['/usr/local/bin/careful_puppet_service_shutdown.sh']
+    }
+  }
 }

--- a/manifests/agent/cron.pp
+++ b/manifests/agent/cron.pp
@@ -211,6 +211,9 @@ class pupmod::agent::cron (
     content => epp("${module_name}/usr/local/bin/careful_puppet_service_shutdown")
   }
 
+# If cron is enabled make sure puppet service is disabled.  Start in background
+# because disabling puppet service will kill all instances of puppet running.
+# See https://tickets.puppetlabs.com/browse/PUP-1320 for more information
   if $facts['puppet_service_enabled'] or $facts['puppet_service_started'] {
     exec { 'careful_puppet_service_shutdown':
       command => '/usr/local/bin/careful_puppet_service_shutdown.sh &',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pupmod",
-  "version": "7.5.0",
+  "version": "7.6.0",
   "author": "SIMP Team",
   "summary": "A puppet module to manage puppetserver and puppet agents",
   "license": "Apache-2.0",

--- a/spec/classes/agent/cron_spec.rb
+++ b/spec/classes/agent/cron_spec.rb
@@ -6,138 +6,157 @@ describe 'pupmod::agent::cron' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
 
-      let(:facts) { os_facts.merge(:ipaddress => '10.0.2.15') }
+      context 'with facts set to defaults' do
+        let(:facts) { os_facts.merge(:ipaddress => '10.0.2.15', :puppet_service_enabled => false, :puppet_service_started => false ) }
 
-      context 'with default parameters' do
-        it { is_expected.to create_class('pupmod::agent::cron') }
-        it { is_expected.to contain_cron('puppetd').with_ensure("absent") }
-        it { is_expected.to contain_cron('puppetagent').with({
-          'command'   => '/usr/local/bin/puppetagent_cron.sh',
-          'minute'    => [27,57],
-          'hour'      => '*',
-          'monthday'  => '*',
-          'month'     => '*',
-          'weekday'   => '*'
-        })}
+        context 'with default params' do
+          it { is_expected.to create_class('pupmod::agent::cron') }
+          it { is_expected.to contain_file('/usr/local/bin/careful_puppet_service_shutdown.sh') }
+          it { is_expected.to_not contain_exec('careful_puppet_service_shutdown') }
+          it { is_expected.to contain_cron('puppetd').with_ensure("absent") }
+          it { is_expected.to contain_cron('puppetagent').with({
+            'command'   => '/usr/local/bin/puppetagent_cron.sh',
+            'minute'    => [27,57],
+            'hour'      => '*',
+            'monthday'  => '*',
+            'month'     => '*',
+            'weekday'   => '*'
+          })}
 
-        it 'uses maxruntime to kill processes in puppetagent_cron.sh' do
-          expected = Regexp.escape('if [[ -n "${pup_status}" && $(( ${now} - ${filedate} )) -gt 1440')
-          is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/#{expected}/)
+          it 'uses maxruntime to kill processes in puppetagent_cron.sh' do
+            expected = Regexp.escape('if [[ -n "${pup_status}" && $(( ${now} - ${filedate} )) -gt 1440')
+            is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/#{expected}/)
+          end
+
+          it 'includes code to break an existing puppet lock in puppetagent_cron.sh' do
+            is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/handles forcibly enabling puppet agent/)
+          end
+
+          it 'uses a computed max disable time to enable puppet in puppetagent_cron.sh' do
+            expected = Regexp.escape('if [[ ${pup_status} -ne 0 && $(( ${now} - ${filedate} )) -gt 16200')
+            is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/#{expected}/)
+          end
+
+          it 'stops the puppet client service in puppetagent_cron.sh' do
+            expected = Regexp.escape('puppet resource service puppet enable=false ensure=false')
+            is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/#{expected}/)
+          end
+
         end
 
-        it 'includes code to break an existing puppet lock in puppetagent_cron.sh' do
-          is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/handles forcibly enabling puppet agent/)
+        context "with 'rand' randomization algorithm for cron minute" do
+          let(:params) {{ :minute => 'rand' }}
+
+          it { is_expected.to contain_cron('puppetagent').with({
+            'command'   => '/usr/local/bin/puppetagent_cron.sh',
+            'minute'    => [27,57],
+            'hour'      => '*',
+            'monthday'  => '*',
+            'month'     => '*',
+            'weekday'   => '*'
+          })}
+
+          it 'uses a computed max disable time to enable puppet in puppetagent_cron.sh' do
+            expected = Regexp.escape('if [[ ${pup_status} -ne 0 && $(( ${now} - ${filedate} )) -gt 16200')
+            is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/#{expected}/)
+          end
         end
 
-        it 'uses a computed max disable time to enable puppet in puppetagent_cron.sh' do
-          expected = Regexp.escape('if [[ ${pup_status} -ne 0 && $(( ${now} - ${filedate} )) -gt 16200')
-          is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/#{expected}/)
+        context "with 'sha256' randomization algorithm for minute" do
+          let(:params) {{ :minute => 'sha256' }}
+
+          it { is_expected.to contain_cron('puppetagent').with({
+            'command'   => '/usr/local/bin/puppetagent_cron.sh',
+            'minute'    => [10,40],
+            'hour'      => '*',
+            'monthday'  => '*',
+            'month'     => '*',
+            'weekday'   => '*'
+          })}
+
+          it 'uses a computed max disable time to enable puppet in puppetagent_cron.sh' do
+            expected = Regexp.escape('if [[ ${pup_status} -ne 0 && $(( ${now} - ${filedate} )) -gt 16200')
+            is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/#{expected}/)
+          end
+        end
+
+        context 'with alternate minute_base' do
+          let(:params) {{ :minute_base => 'foo' }}
+          it { is_expected.to contain_cron('puppetagent').with({
+            'command'   => '/usr/local/bin/puppetagent_cron.sh',
+            'minute'    => [29,59],
+            'hour'      => '*',
+            'monthday'  => '*',
+            'month'     => '*',
+            'weekday'   => '*'
+          })}
+        end
+
+        context "with interval enabled" do
+          let(:params) {{ :minute => 'nil' }}
+          it { is_expected.to contain_cron('puppetagent').with({
+            'minute'    => '*/30',
+          })}
+
+          it 'uses a computed max disable time to enable puppet in puppetagent_cron.sh' do
+            expected = Regexp.escape('if [[ ${pup_status} -ne 0 && $(( ${now} - ${filedate} )) -gt 16200')
+            is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/#{expected}/)
+          end
+        end
+
+        context 'with specific cron parameters specified' do
+          let(:params) {{ 
+            :minute   => '1',
+            :hour     => '2',
+            :monthday => '3',
+            :month    => '4',
+            :weekday  => '5'
+          }}
+
+          it { is_expected.to contain_cron('puppetagent').with({
+            'command'   => '/usr/local/bin/puppetagent_cron.sh',
+            'minute'    => '1',
+            'hour'      => '2',
+            'monthday'  => '3',
+            'month'     => '4',
+            'weekday'   => '5'
+          })}
+        end
+
+        context 'with altername maxruntime' do
+          let(:params) {{ :maxruntime => 10 }}
+
+          it 'uses maxruntime to kill processes in puppetagent_cron.sh' do
+            expected = Regexp.escape('if [[ -n "${pup_status}" && $(( ${now} - ${filedate} )) -gt 600')
+            is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/#{expected}/)
+          end
+        end
+
+        context 'with break_puppet_lock disabled' do
+          let(:params) {{ :break_puppet_lock => false }}
+          it { is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/handles puppet processes which have been running longer than maxruntime/) }
+          it { is_expected.to_not contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/handles forcibly enabling puppet agent/) }
+        end
+
+
+        context 'with max_disable_time specified' do
+          let(:params) {{ :max_disable_time => 5 }}
+
+          it 'uses max_disable_time to enable puppet in puppetagent_cron.sh' do
+            expected = Regexp.escape('if [[ ${pup_status} -ne 0 && $(( ${now} - ${filedate} )) -gt 300')
+            is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/#{expected}/)
+          end
         end
       end
 
-      context "with 'rand' randomization algorithm for cron minute" do
-        let(:params) {{ :minute => 'rand' }}
+      context 'with puppet service enabled' do
+        let(:facts) { os_facts.merge(:ipaddress => '10.0.2.15', :puppet_service_enabled => true, :puppet_service_started => true ) }
 
-        it { is_expected.to contain_cron('puppetagent').with({
-          'command'   => '/usr/local/bin/puppetagent_cron.sh',
-          'minute'    => [27,57],
-          'hour'      => '*',
-          'monthday'  => '*',
-          'month'     => '*',
-          'weekday'   => '*'
-        })}
-
-        it 'uses a computed max disable time to enable puppet in puppetagent_cron.sh' do
-          expected = Regexp.escape('if [[ ${pup_status} -ne 0 && $(( ${now} - ${filedate} )) -gt 16200')
-          is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/#{expected}/)
+        it 'should exec script to disable puppet service' do
+          is_expected.to contain_exec('careful_puppet_service_shutdown')
         end
       end
 
-      context "with 'sha256' randomization algorithm for minute" do
-        let(:params) {{ :minute => 'sha256' }}
-
-        it { is_expected.to contain_cron('puppetagent').with({
-          'command'   => '/usr/local/bin/puppetagent_cron.sh',
-          'minute'    => [10,40],
-          'hour'      => '*',
-          'monthday'  => '*',
-          'month'     => '*',
-          'weekday'   => '*'
-        })}
-
-        it 'uses a computed max disable time to enable puppet in puppetagent_cron.sh' do
-          expected = Regexp.escape('if [[ ${pup_status} -ne 0 && $(( ${now} - ${filedate} )) -gt 16200')
-          is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/#{expected}/)
-        end
-      end
-
-      context 'with alternate minute_base' do
-        let(:params) {{ :minute_base => 'foo' }}
-        it { is_expected.to contain_cron('puppetagent').with({
-          'command'   => '/usr/local/bin/puppetagent_cron.sh',
-          'minute'    => [29,59],
-          'hour'      => '*',
-          'monthday'  => '*',
-          'month'     => '*',
-          'weekday'   => '*'
-        })}
-      end
-
-      context "with interval enabled" do
-        let(:params) {{ :minute => 'nil' }}
-        it { is_expected.to contain_cron('puppetagent').with({
-          'minute'    => '*/30',
-        })}
-
-        it 'uses a computed max disable time to enable puppet in puppetagent_cron.sh' do
-          expected = Regexp.escape('if [[ ${pup_status} -ne 0 && $(( ${now} - ${filedate} )) -gt 16200')
-          is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/#{expected}/)
-        end
-      end
-
-      context 'with specific cron parameters specified' do
-        let(:params) {{ 
-          :minute   => '1',
-          :hour     => '2',
-          :monthday => '3',
-          :month    => '4',
-          :weekday  => '5'
-        }}
-
-        it { is_expected.to contain_cron('puppetagent').with({
-          'command'   => '/usr/local/bin/puppetagent_cron.sh',
-          'minute'    => '1',
-          'hour'      => '2',
-          'monthday'  => '3',
-          'month'     => '4',
-          'weekday'   => '5'
-        })}
-      end
-
-      context 'with altername maxruntime' do
-        let(:params) {{ :maxruntime => 10 }}
-
-        it 'uses maxruntime to kill processes in puppetagent_cron.sh' do
-          expected = Regexp.escape('if [[ -n "${pup_status}" && $(( ${now} - ${filedate} )) -gt 600')
-          is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/#{expected}/)
-        end
-      end
-
-      context 'with break_puppet_lock disabled' do
-        let(:params) {{ :break_puppet_lock => false }}
-        it { is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/handles puppet processes which have been running longer than maxruntime/) }
-        it { is_expected.to_not contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/handles forcibly enabling puppet agent/) }
-      end
-
-
-      context 'with max_disable_time specified' do
-        let(:params) {{ :max_disable_time => 5 }}
-
-        it 'uses max_disable_time to enable puppet in puppetagent_cron.sh' do
-          expected = Regexp.escape('if [[ ${pup_status} -ne 0 && $(( ${now} - ${filedate} )) -gt 300')
-          is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_content(/#{expected}/)
-        end
-      end
     end
   end
 end

--- a/spec/classes/init_test_spec.rb
+++ b/spec/classes/init_test_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+audit_content = File.open("#{File.dirname(__FILE__)}/data/auditd.txt", "rb").read;
+
+describe 'pupmod' do
+  on_supported_os.each do |os, os_facts|
+    before :all do
+      @extras = { :puppet_settings => {
+        'master' => {
+          'rest_authconfig' => '/etc/puppetlabs/puppet/authconf.conf'
+        }}}
+    end
+    context "on #{os}" do
+      let(:facts){ @extras.merge(os_facts) }
+      [
+        'PC1',
+        'PE'
+      ].each do |distribution|
+        context "with server_distribution = #{distribution}" do
+          let(:params) {{ :server_distribution => distribution, :puppet_server => '1.2.3.4' }}
+          describe "with default parameters" do
+            it { is_expected.to compile.with_all_deps }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/files/systemctl_status_off.txt
+++ b/spec/files/systemctl_status_off.txt
@@ -1,0 +1,3 @@
+● puppet.service - Puppet agent
+   Loaded: loaded (/usr/lib/systemd/system/puppet.service; disabled; vendor preset: disabled)
+   Active: inactive (dead)

--- a/spec/files/systemctl_status_on.txt
+++ b/spec/files/systemctl_status_on.txt
@@ -1,0 +1,7 @@
+● puppet.service - Puppet agent
+   Loaded: loaded (/usr/lib/systemd/system/puppet.service; disabled; vendor preset: disabled)
+   Active: active (running) since Tue 2018-04-17 14:30:50 EDT; 5s ago
+ Main PID: 22354
+   CGroup: /system.slice/puppet.service
+           ├─22354 n/a
+           └─22389 n/a

--- a/spec/unit/facter/puppet_service_spec.rb
+++ b/spec/unit/facter/puppet_service_spec.rb
@@ -1,0 +1,69 @@
+require "spec_helper"
+
+#
+#   This tests both the puppet_service_enabled and puppet_service_started facts.
+#
+describe 'puppet_service_enabled', :type => :fact do
+  before :each do
+     Facter.clear
+     Facter.clear_messages
+  end
+
+  context 'with systemd on linux' do
+    before do
+      Facter.fact(:kernel).stubs(:value).returns(:linux)
+      Facter.add(:service_provider) { setcode { 'systemd' } }
+    end
+
+    context 'with puppet service on' do
+      before(:each) do
+        Facter::Core::Execution.stubs(:execute).with('/usr/bin/systemctl is-enabled puppet.service').returns 'enabled'
+        Facter::Core::Execution.stubs(:execute).with('/usr/bin/systemctl status puppet.service').returns File.read('spec/files/systemctl_status_on.txt')
+      end
+      it 'should return true' do
+        expect(Facter.fact(:puppet_service_enabled).value).to be true
+        expect(Facter.fact(:puppet_service_started).value).to be true
+      end
+    end
+
+    context 'with puppet service off' do
+      before(:each) do
+        Facter::Core::Execution.stubs(:execute).with('/usr/bin/systemctl is-enabled puppet.service').returns 'disabled'
+        Facter::Core::Execution.stubs(:execute).with('/usr/bin/systemctl status puppet.service').returns File.read('spec/files/systemctl_status_off.txt')
+      end
+      it 'should return false' do
+        expect(Facter.value(:puppet_service_enabled)).to be false
+        expect(Facter.value(:puppet_service_started)).to be false
+      end
+    end
+  end
+
+  context 'without systemd on linux' do
+    before do
+      Facter.fact(:kernel).stubs(:value).returns(:linux)
+      Facter.add(:service_provider) { setcode { 'sysv' } }
+    end
+
+    context 'with puppet service on' do
+      before(:each) do
+        Facter::Core::Execution.stubs(:execute).with('/sbin/chkconfig --list | grep -w puppet').returns 'puppet           0:off 1:off 2:off 3:on 4:on 5:on 6:off'
+        Facter::Core::Execution.stubs(:execute).with('/sbin/service puppet status').returns 'puppet (pid  24188) is running...'
+      end
+      it 'should return true' do
+        expect(Facter.value(:puppet_service_enabled)).to be true
+        expect(Facter.value(:puppet_service_started)).to be true
+      end
+    end
+
+    context 'with puppet service off' do
+      before(:each) do
+        Facter::Core::Execution.stubs(:execute).with('/sbin/chkconfig --list | grep -w puppet').returns 'puppet           0:off 1:off 2:off 3:off 4:off 5:off 6:off '
+        Facter::Core::Execution.stubs(:execute).with('/sbin/service puppet status').returns 'this service is stopped'
+      end
+      it 'should return false' do
+        expect(Facter.value(:puppet_service_enabled)).to be false
+        expect(Facter.value(:puppet_service_started)).to be false
+      end
+    end
+  end
+end

--- a/spec/unit/facter/puppet_service_spec.rb
+++ b/spec/unit/facter/puppet_service_spec.rb
@@ -12,7 +12,7 @@ describe 'puppet_service_enabled', :type => :fact do
   context 'with systemd on linux' do
     before do
       Facter.fact(:kernel).stubs(:value).returns(:linux)
-      Facter.add(:service_provider) { setcode { 'systemd' } }
+      Facter.add(:init_systems) { setcode { 'systemd' } }
     end
 
     context 'with puppet service on' do
@@ -41,7 +41,7 @@ describe 'puppet_service_enabled', :type => :fact do
   context 'without systemd on linux' do
     before do
       Facter.fact(:kernel).stubs(:value).returns(:linux)
-      Facter.add(:service_provider) { setcode { 'sysv' } }
+      Facter.add(:init_systems) { setcode { 'sysv' } }
     end
 
     context 'with puppet service on' do

--- a/templates/usr/local/bin/careful_puppet_service_shutdown.epp
+++ b/templates/usr/local/bin/careful_puppet_service_shutdown.epp
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# This command will check if puppet is running before changing the status of the service.
+# You can't disable the puppet service from inside a puppet run.
+# See https://tickets.puppetlabs.com/browse/PUP-1320 for more information
+#
+
+PATH="/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin";
+
+puppet_run_lockfile="$(puppet config print agent_catalog_run_lockfile)";
+
+# wait for any current puppet run to finish
+countdown=120
+while [ -f ${puppet_run_lockfile} -a $countdown -gt 0 ]; do
+ /bin/sleep 5
+ ((countdown--))
+done
+
+if [ $countdown -gt 0 ]; then
+  puppet resource service puppet enable=false ensure=false 2>&1 > /dev/null
+else
+  /bin/logger -s -p 'local6.warn' -t 'puppet' "$0 :Script could not stop puppet service.  Lock file, ${puppet_run_lockfile}, remained longer than 10 minutes."
+fi

--- a/templates/usr/local/bin/puppetagent_cron.epp
+++ b/templates/usr/local/bin/puppetagent_cron.epp
@@ -57,5 +57,9 @@ fi
 
 # Run Puppet if we don't have any locks
 if [ ! -f "${puppet_disable_lockfile}" ] && [ ! -f "${puppet_run_lockfile}" ]; then
+  # Disable puppet client service so puppet only cronjob runs puppet client.
+  # Can't make a service resource in puppet.  See https://tickets.puppetlabs.com/browse/PUP-1320.
+  puppet resource service puppet enable=false ensure=false 2>&1 > /dev/null
+  # Run the puppet agent.
   puppet agent --onetime --no-daemonize --no-show_diff;
 fi


### PR DESCRIPTION
  - added a line to cron script to disable puppet service before
    running puppet in cron mode.
  - added exec to agent/cron manifest to make sure puppet service
    was disabled before cron runs first time.

SIMP-4662 #close
SIMP-4811 #close