### PR TITLE
(SIMP-4828) Fix issue in simp_generate_types

### DIFF
--- a/templates/usr/local/sbin/simp_generate_types.epp
+++ b/templates/usr/local/sbin/simp_generate_types.epp
@@ -92,7 +92,7 @@ options.target_environments.each do |env|
   sleep(delay)
 
   # Prevent running on the same environment simultaneously
-  next unless %{ps --no-headers -o args -wwC #{puppet_cmd}}.
+  next unless %x{ps --no-headers -o args -wwC #{puppet_cmd}}.
                 lines.
                 grep(/generate types/).
                 grep(/--environment\s+#{env}(\s+|$)/).


### PR DESCRIPTION
The code that prevents running on an environment that is already being
processed was missing the '%x' required for executing the process list
command