### PR TITLE
(SIMP-5021) Incorrect JAVA tmpdir in pupmod::master::sysconfig

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Jul 19 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 7.6.1-0
+- Fixed bug in which the JAVA tmpdir path for the puppetserver was
+  incorrectly set.  This could cause puppetserver RPM upgrades to fail.
+
 * Thu Jul 12 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.6.1-0
 - Fixed the new `simp_generate_types` script to ensure that the permissions on
   the created directory are correctly set.

--- a/manifests/master/sysconfig.pp
+++ b/manifests/master/sysconfig.pp
@@ -73,7 +73,8 @@ class pupmod::master::sysconfig (
 ) inherits pupmod {
   unless (mock == true) {
     if empty($java_temp_dir) {
-      $_java_temp_dir = "${::pupmod::vardir}/pserver_tmp"
+      # puppet_settings.master.server_datadir is not always present, but its parent is
+      $_java_temp_dir = "${dirname(fact('puppet_settings.master.server_datadir'))}/pserver_tmp"
     }
     else {
       $_java_temp_dir = $java_temp_dir

--- a/metadata.json
+++ b/metadata.json
@@ -23,7 +23,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.0 < 5.0.0"
+      "version_requirement": ">= 4.19.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/inifile",

--- a/spec/acceptance/suites/default/05_generate_types_spec.rb
+++ b/spec/acceptance/suites/default/05_generate_types_spec.rb
@@ -19,7 +19,7 @@ describe 'incron driven puppet generate types'  do
       end
 
       it 'should create the resource cache in a new environment' do
-        on(host, "cp -r #{environment_path}/production #{environment_path}/new_environment")
+        on(host, "cp -ra #{environment_path}/production #{environment_path}/new_environment")
         # Give it some time to generate everything
         retry_on(host, "ls -al #{environment_path}/new_environment/.resource_types", :max_retries => 35)
       end

--- a/spec/classes/master/data/puppetserver.txt
+++ b/spec/classes/master/data/puppetserver.txt
@@ -2,7 +2,7 @@
 JAVA_BIN="/usr/bin/java"
 
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
-JAVA_ARGS="-Xms245m -Xmx245m -Djava.io.tmpdir=/opt/puppetlabs/puppet/cache/pserver_tmp "
+JAVA_ARGS="-Xms245m -Xmx245m -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp "
 
 # These normally shouldn't need to be edited if using OS packages
 USER="puppet"

--- a/spec/classes/master/sysconfig_spec.rb
+++ b/spec/classes/master/sysconfig_spec.rb
@@ -8,6 +8,7 @@ describe 'pupmod::master::sysconfig' do
           'rest_authconfig' => '/etc/puppetlabs/puppet/authconf.conf'
       }}}
     end
+
     context "on #{os}" do
 
       ['PE', 'PC1'].each do |server_distribution|
@@ -47,18 +48,21 @@ describe 'pupmod::master::sysconfig' do
           else
             let(:facts){ @extras.merge(os_facts).merge(:memorysize_mb => '490.16') }
 
-            puppetserver_content = File.open("#{File.dirname(__FILE__)}/data/puppetserver.txt", "rb").read
+            it do
+              puppetserver_content = File.read("#{File.dirname(__FILE__)}/data/puppetserver.txt")
+              puppetserver_content.gsub!('%PUPPETSERVER_JAVA_TMPDIR_ROOT%',
+                File.dirname(facts[:puppet_settings][:master][:server_datadir]))
 
-            it { is_expected.to contain_file('/etc/sysconfig/puppetserver').with(
-              {
+              is_expected.to contain_file('/etc/sysconfig/puppetserver').with( {
                 'owner'   => 'root',
                 'group'   => 'puppet',
                 'mode'    => '0640',
                 'content' => puppetserver_content
-              }
-            )}
+              } )
+            end
+
             it { is_expected.to create_class('pupmod::master::sysconfig') }
-            it { is_expected.to contain_file('/opt/puppetlabs/puppet/cache/pserver_tmp').with(
+            it { is_expected.to contain_file("#{File.dirname(facts[:puppet_settings][:master][:server_datadir])}/pserver_tmp").with(
               {
                 'owner'  => 'puppet',
                 'group'  => 'puppet',

--- a/spec/defines/pass_two_spec.rb
+++ b/spec/defines/pass_two_spec.rb
@@ -203,7 +203,8 @@ describe 'pupmod::pass_two' do
                     "2020.1.0" => false,
                     "2021.1.0" => false,
                   }.each do |pe_version, tmpdir|
-                    it { is_expected.to contain_file("/opt/puppetlabs/puppet/cache/pserver_tmp")}
+                    it { is_expected.to contain_file("#{File.dirname(facts[:puppet_settings][:master][:server_datadir])}/pserver_tmp")}
+
                     context "when pe_version == #{pe_version}" do
                       let (:facts) do
                         { "pe_build" => pe_version }.merge(facts)

--- a/templates/usr/local/sbin/simp_generate_types.epp
+++ b/templates/usr/local/sbin/simp_generate_types.epp
@@ -29,6 +29,7 @@ OptionParser.new do |opts|
     if path == 'all'
       options.target_environments = environment_paths.compact
     else
+      path << '/' if (File.directory?(path) and path[-1] != '/')
       options.target_environments = Array(environment_paths.find do |env|
         path.start_with?("#{env}/")
       end).compact
@@ -56,7 +57,7 @@ OptionParser.new do |opts|
 
   options.help = opts.help
 
-  end.parse!
+end.parse!
 
 fh = File.open(options.logfile, 'w') if options.logfile
 


### PR DESCRIPTION
- Fixed bug in which the JAVA tmpdir path for the puppetserver was
  incorrectly set.  This could cause puppetserver RPM upgrades to fail.
- Fixed bug in simp_generate_types whereby it was failing when a
  directory path missing the trailing '/' was passed as a target path

SIMP-5021 #close