### PR TITLE
(SIMP-5337) Properly manage the puppet service

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Sep 11 2018 Steven Pritchard <steven.pritchard@onyxpoint.com> - 7.7.1-0
+- Unconditionally manages the puppet service
+- Remove the (apparently) broken status logic on the puppet service
+
 * Mon Sep 10 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 7.7.0-0
 - Update Hiera 4 to Hiera 5
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -192,23 +192,17 @@ class pupmod (
 
     if $daemonize {
       cron { 'puppetagent': ensure => 'absent' }
-
-      # This has been designed to explicitly be the antithesis of the
-      # cron in the 'false' statement above.
-      #
-      # Anything else is wholly irrelevant, since it's puppet checking
-      # on itself while it's running.
-      service { 'puppet':
-        ensure     => 'running',
-        enable     => true,
-        hasrestart => true,
-        hasstatus  => false,
-        status     => '/usr/bin/test `/bin/ps --no-headers -fC puppetd,"puppet agent" | /usr/bin/wc -l` -ge 1 -a ! `/bin/ps --no-headers -fC puppetd,"puppet agent" | /bin/grep -c "no-daemonize"` -ge 1',
-        subscribe  => File["${confdir}/puppet.conf"]
-      }
     }
     else {
       include 'pupmod::agent::cron'
+    }
+
+    service { 'puppet':
+      ensure     => $daemonize ? { true => running, default => stopped },
+      enable     => $daemonize,
+      hasrestart => true,
+      hasstatus  => true,
+      subscribe  => File["${confdir}/puppet.conf"]
     }
 
     pupmod::conf { 'agent_daemonize':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -191,14 +191,18 @@ class pupmod (
     package { 'puppet-agent': ensure => $package_ensure }
 
     if $daemonize {
+      $_puppet_service_ensure = 'running'
+
       cron { 'puppetagent': ensure => 'absent' }
     }
     else {
+      $_puppet_service_ensure = 'stopped'
+
       include 'pupmod::agent::cron'
     }
 
     service { 'puppet':
-      ensure     => $daemonize ? { true => running, default => stopped },
+      ensure     => $_puppet_service_ensure,
       enable     => $daemonize,
       hasrestart => true,
       hasstatus  => true,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pupmod",
-  "version": "7.7.0",
+  "version": "7.7.1",
   "author": "SIMP Team",
   "summary": "A puppet module to manage puppetserver and puppet agents",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -24,6 +24,13 @@ describe 'pupmod' do
             it { is_expected.not_to contain_class('haveged') }
             it { is_expected.to contain_package('puppet-agent').with_ensure('installed') }
             it { is_expected.to contain_class('pupmod::agent::cron') }
+            it { is_expected.to contain_service('puppet').with({
+              'ensure'     => 'stopped',
+              'enable'     => false,
+              'hasrestart' => true,
+              'hasstatus'  => true,
+              'subscribe'  => 'File[/etc/puppetlabs/puppet/puppet.conf]'
+            }) }
             it { is_expected.to contain_pupmod__conf('agent_daemonize').with({
               'section' => 'agent',
               'setting' => 'daemonize',
@@ -178,8 +185,7 @@ describe 'pupmod' do
                 'ensure'     => 'running',
                 'enable'     => true,
                 'hasrestart' => true,
-                'hasstatus'  => false,
-                'status'     => '/usr/bin/test `/bin/ps --no-headers -fC puppetd,"puppet agent" | /usr/bin/wc -l` -ge 1 -a ! `/bin/ps --no-headers -fC puppetd,"puppet agent" | /bin/grep -c "no-daemonize"` -ge 1',
+                'hasstatus'  => true,
                 'subscribe'  => 'File[/etc/puppetlabs/puppet/puppet.conf]'
               }) }
             end


### PR DESCRIPTION
This change unconditionally manages the puppet service and removes the
(apparently) broken status logic.

SIMP-5337 #close