### PR TITLE
(SIMP-5457) Drop trusted_server_facts in Pup 5.+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ language: ruby
 cache: bundler
 sudo: false
 
+
 bundler_args: --without development system_tests --path .vendor
 
 notifications:
@@ -53,12 +54,12 @@ jobs:
 
     - stage: deploy
       rvm: 2.4.4
+      if: 'fork = false AND tag = true'
       script:
         - true
       before_deploy:
         - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
         - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
-
       deploy:
         - provider: releases
           api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 # The testing matrix considers ruby/puppet versions supported by SIMP and PE:
 # ------------------------------------------------------------------------------
-#  release    pup   ruby      eol
-# PE 2017.2   4.10  2.1.9  TBD
+#  release    pup   ruby   eol
+# SIMP 6.2    4.10  2.1.9  TBD
+# PE 2016.4   ""    ""     2018/12/31
+# PE 2017.3   5.3   2.4.4  2018/12/31
+# SIMP 6.3    5.5   ""     TBD
+# PE 2018.1   ""    ""     2020/05/??
 ---
 language: ruby
 cache: bundler
@@ -23,7 +27,7 @@ before_install:
 jobs:
   include:
     - stage: check
-      rvm: 2.4.1
+      rvm: 2.4.4
       env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5"
       script:
         - bundle exec rake check:dot_underscore
@@ -36,8 +40,8 @@ jobs:
         - bundle exec puppet module build
 
     - stage: spec
-      rvm: 2.4.1
-      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
+      rvm: 2.4.4
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.5.0"
       script:
         - bundle exec rake spec
 
@@ -48,7 +52,7 @@ jobs:
         - bundle exec rake spec
 
     - stage: deploy
-      rvm: 2.4.1
+      rvm: 2.4.4
       script:
         - true
       before_deploy:
@@ -69,5 +73,5 @@ jobs:
             secure: "OhZAD0tAMFjcLziw9DNVExzGWIg6vZFgGHgLKwGgkF7w4cb2VCZ/sk0v1viMcGsutIrt3WguJjqAHPblk08dMx4NtTDzBI49IwcRZ4aapu1gpa7KuytXHbEsaM+tw75W3GftC7JTq4NyHgnhG3HB13iQFPMj55VRPZufNVsCGDIgtQGmUlwHaltpV57qUJyk/q4KBauq3uOb8DmAWG05PUgayXpPLwahKZ71LFRLKR6Q0/5jFdz081nOcaPCf7ZgxX16MoCUjtk6NUD9S3e9EbgxBDfIeELTpXp/LlOZkopSlas3NAT3ksWG3gUpKjBXTTY9H/vaoNxOABvFvz2uiTbcSwGo2wI/UwBECG75fDmKbVpqyGxFmmJNtMK40HPEf4JfC1IBJy/mzxL0/ugcHDpKOOACO7DbknnDi53pkWa1RGBNRja3X/GUBF7zsqTX21v9QvTUOEQm8wwO4N5l6Dv7Tf+IAFY8pUmA2RLNGHrYjkd40gWCTnHAoG8G9UekHrVwHcfZqiAmGmisDkjNQAXIP434oXIPrZJG1X3+8vPz45NKOC7Zf5juzDz+FOtryWcB9WKEFF7zDU8rQrDu3CSH0bM+GKXdIaEeCUgsLcqs0wVdR1xTpRf04j+YZJEgEydJzJ+LY5YH4oBwur/uSK2RxN92kcZGRL97i22/4AA="
           on:
             tags: true
-            rvm: 2.4.1
+            rvm: 2.4.4
             condition: '($SKIP_FORGE_PUBLISH != true)'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Oct 15 2018 Chris Tessmer <chris.tessmer@onyxpoint.com> - 7.8.0-0
+- Add `ensure` parameter to `pupmod::conf``
+- Ensure that `trusted_server_facts` is removed for Puppet 5.+ (PUP-6112)
+
 * Tue Sep 11 2018 Steven Pritchard <steven.pritchard@onyxpoint.com> - 7.7.1-0
 - Unconditionally manages the puppet service
 - Remove the (apparently) broken status logic on the puppet service

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem_sources.each { |gem_source| source gem_source }
 
 group :test do
   gem 'rake'
-  gem 'puppet', ENV.fetch('PUPPET_VERSION',  '~> 4.0')
+  gem 'puppet', ENV.fetch('PUPPET_VERSION',  '~> 5.0')
   gem 'rspec'
   gem 'rspec-puppet'
   gem 'hiera-puppet-helper'

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -18,18 +18,23 @@
 # @param section
 #   The Sections of the puppet.conf to set.
 #
+# @param ensure
+#  Determines whether the specified setting should exist.
+#
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 define pupmod::conf (
   String $setting,
   Scalar $value,
   String $confdir,
-  String $section = 'main'
+  String $section = 'main',
+  Enum['present', 'absent'] $ensure = 'present',
 ) {
 
   $l_name = "${module_name}_${name}"
 
   ini_setting { $l_name:
+    ensure  => $ensure,
     path    => "${confdir}/puppet.conf",
     section => $section,
     setting => $setting,

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -351,7 +351,14 @@ class pupmod::master (
       notify  => Service[$service]
     }
 
+    # `trusted_server_facts` deprecated in Puppet 5.0.0 (PUP-6112)
+    $trusted_server_facts = (versioncmp($facts['puppetversion'], '5.0')) ? {
+      -1      => 'present',
+      default => 'absent',
+    }
+
     pupmod::conf { 'trusted_server_facts':
+      ensure  => $trusted_server_facts,
       confdir => $puppet_confdir,
       setting => 'trusted_server_facts',
       value   => true,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pupmod",
-  "version": "7.7.1",
+  "version": "7.8.0",
   "author": "SIMP Team",
   "summary": "A puppet module to manage puppetserver and puppet agents",
   "license": "Apache-2.0",

--- a/spec/classes/master_spec.rb
+++ b/spec/classes/master_spec.rb
@@ -10,7 +10,7 @@ describe 'pupmod::master' do
     }}}
   end
 
-  puppetserver_versions = ['2.7.0', '5.0.0', '5.1.0']
+  puppetserver_versions = ['5.3.5' '5.0.0', '2.7.0']
 
   on_supported_os.each do |os, os_facts|
     puppetserver_versions.each do |puppetserver_version|
@@ -294,11 +294,20 @@ describe 'pupmod::master' do
             }
           end
 
-          it { is_expected.to contain_pupmod__conf('trusted_server_facts').with({
-            'setting' => 'trusted_server_facts',
-            'value'   => true,
-            'notify'  => 'Service[puppetserver]'
-          }) }
+          it 'handles `trusted_server_facts` correctly for the Puppet version' do
+            if (Puppet.version.split('.').first >= '5')
+              is_expected.to contain_pupmod__conf('trusted_server_facts').with({
+                'ensure' => 'absent'
+              })
+            else
+              is_expected.to contain_pupmod__conf('trusted_server_facts').with({
+                'ensure'  => 'present',
+                'setting' => 'trusted_server_facts',
+                'value'   => true,
+                'notify'  => 'Service[puppetserver]'
+              })
+            end
+          end
 
           it { is_expected.to contain_pupmod__conf('master_environmentpath').with({
             'section' => 'master',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,19 +9,13 @@ require 'pathname'
 fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
 module_name = File.basename(File.expand_path(File.join(__FILE__,'../..')))
 
-# Add fixture lib dirs to LOAD_PATH. Work-around for PUP-3336
-if Puppet.version < "4.0.0"
-  Dir["#{fixture_path}/modules/*/lib"].entries.each do |lib_dir|
-    $LOAD_PATH << lib_dir
-  end
-end
-
-
-if !ENV.key?( 'TRUSTED_NODE_DATA' )
-  warn '== WARNING: TRUSTED_NODE_DATA is unset, using TRUSTED_NODE_DATA=yes'
-  ENV['TRUSTED_NODE_DATA']='yes'
-end
-
+#### Add fixture lib dirs to LOAD_PATH. Work-around for PUP-3336
+###if Puppet.version < "4.0.0"
+###  Dir["#{fixture_path}/modules/*/lib"].entries.each do |lib_dir|
+###    $LOAD_PATH << lib_dir
+###  end
+###end
+###
 
 if ENV['PUPPET_DEBUG']
   Puppet::Util::Log.level = :debug


### PR DESCRIPTION
The `trusted_server_facts` setting was supposed to be removed in Puppet
4.0.0, but was actually removed in 5.0.0 ([PUP-6112][0]). Starting with
Puppet 5.0.0, the presence of this setting will cause each puppet run to
emit the warning:

    Warning: Setting trusted_server_facts is deprecated.

This patch fixes the issue by:

* Adding an `ensure` parameter to `pupmod::conf` that can be set to
  `absent`, removing the setting entirely.
* Adding logic to `pupmod::master` that removes the
  `trusted_server_facts` setting on Puppet 5.+

SIMP-5457 #close

[0]: https://tickets.puppetlabs.com/browse/PUP-6112