### PR TITLE
(SIMP-5456) Remove deprecated `[master] ca` 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
   include:
     - stage: check
       rvm: 2.4.4
-      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5"
+      env: STRICT_VARIABLES=yes PUPPET_VERSION="~> 5"
       script:
         - bundle exec rake check:dot_underscore
         - bundle exec rake check:test_file
@@ -42,13 +42,13 @@ jobs:
 
     - stage: spec
       rvm: 2.4.4
-      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.5.7"
+      env: STRICT_VARIABLES=yes PUPPET_VERSION="~> 5.5.7"
       script:
         - bundle exec rake spec
 
     - stage: spec
       rvm: 2.1.9
-      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.10.0"
+      env: STRICT_VARIABLES=yes PUPPET_VERSION="~> 4.10.0"
       script:
         - bundle exec rake spec
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
 
     - stage: spec
       rvm: 2.4.4
-      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.5.0"
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.5.7"
       script:
         - bundle exec rake spec
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Oct 29 2018 Chris Tessmer <chris.tessmer@onyxpoint.com> - 7.7.1-0
+- Remove deprecated `[master] ca` setting when `ca = true` in Puppet 5.5.6+
+- Remove `[master] ca` setting in Puppet 6+
+
 * Mon Oct 15 2018 Chris Tessmer <chris.tessmer@onyxpoint.com> - 7.7.0-0
 - Add `ensure` parameter to `pupmod::conf``
 - Ensure that `trusted_server_facts` is removed for Puppet 5.+ (PUP-6112)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Mon Oct 29 2018 Chris Tessmer <chris.tessmer@onyxpoint.com> - 7.7.1-0
+* Mon Oct 29 2018 Chris Tessmer <chris.tessmer@onyxpoint.com> - 7.7.0-0
 - Remove deprecated `[master] ca` setting when `ca = true` in Puppet 5.5.6+
 - Remove `[master] ca` setting in Puppet 6+
 

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -389,11 +389,26 @@ class pupmod::master (
       notify  => Service[$service]
     }
 
+    # `[master] ca` is deprecated, as of Puppet 5.5.6 (SIMP-5456), and removed
+    # in Puppet 6 (PUP-9158).  All
+    if versioncmp($facts['puppetversion'], '6.0') >= 0 {
+      $_ensure_master_ca = 'absent'
+    }
+    elsif versioncmp($facts['puppetversion'], '5.5.6') {
+      $_ensure_master_ca = $enable_ca ? {
+        true    => 'absent',
+        default => 'present',
+      }
+    } else {
+      $_ensure_master_ca = 'present'
+    }
+
     pupmod::conf { 'master_ca':
       section => 'master',
-      confdir => $puppet_confdir,
       setting => 'ca',
       value   => $enable_ca,
+      confdir => $puppet_confdir,
+      ensure  => $_ensure_master_ca,
       notify  => Service[$service]
     }
 

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -390,11 +390,18 @@ class pupmod::master (
     }
 
     # `[master] ca` is deprecated, as of Puppet 5.5.6 (SIMP-5456), and removed
-    # in Puppet 6 (PUP-9158).  All
+    # in Puppet 6 (PUP-9158).
     if versioncmp($facts['puppetversion'], '6.0') >= 0 {
       $_ensure_master_ca = 'absent'
     }
-    elsif versioncmp($facts['puppetversion'], '5.5.6') {
+    elsif versioncmp($facts['puppetversion'], '5.5.6') >= 0 {
+      # Puppet will emit warning messages whenever deprecated settings are
+      # encountered in `puppet.conf`.  To avoid this, we remove the setting
+      # if it is the same as the default `ca = true`.
+      #
+      # NOTE: Although the condition tests for 5.5.6 (when `ca` was marked as
+      #       deprecated), due to the bug PUP-9266 this logic will not prevent
+      #       deprecation warnings until the release of 5.5.8.
       $_ensure_master_ca = $enable_ca ? {
         true    => 'absent',
         default => 'present',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pupmod",
-  "version": "7.7.1",
+  "version": "7.7.0",
   "author": "SIMP Team",
   "summary": "A puppet module to manage puppetserver and puppet agents",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pupmod",
-  "version": "7.7.0",
+  "version": "7.7.1",
   "author": "SIMP Team",
   "summary": "A puppet module to manage puppetserver and puppet agents",
   "license": "Apache-2.0",


### PR DESCRIPTION
Puppet 5.5.7 [PUP-9158][0] removed the puppet.conf deprecation notices
for `ca_ttl`, but the `[master]` section's [`ca` setting remains
deprecated][1], causing `puppet bootstrap` and every subsequent puppet
run to emit warnings.

The `[master] ca` setting will be removed completely in Puppet
6, as puppetserver's trapperkeeper [will take over CA duties][2].

This patch:

  - ensures `[master] ca` when Puppet < 5.5.6
  - removes `[master] ca` when Puppet >= 6
  - removes `[master] ca` when Puppet >= 5.5.6, unless `$ensure_ca` =
    false (allowing users to explicitly disable the Puppet CA)

Note that, until the release of `puppet-agent 5.5.8`, there is another
bug ([PUP-9266][3]) where deprecation warnings will be emitted when
the setting is used in code, instead of just when `[master] ca` is set 
in `puppet.conf`.


[0]: https://tickets.puppetlabs.com/browse/PUP-9158
[1]: https://github.com/puppetlabs/puppet/pull/7109/files#diff-908b50f77db1b5645f5c125514deccd3R1299
[2]: https://tickets.puppetlabs.com/browse/PUP-9158?focusedCommentId=601606#comment-601606
[3]: https://tickets.puppetlabs.com/browse/PUP-9266

SIMP-5456 #close