### PR TITLE
(SIMP-5707) Work around Puppet 5 exec issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ stages:
   - check
   - spec
   - name: deploy
-    if: 'fork = false AND tag = true'
+    if: 'tag IS present'
 
 bundler_args: --without development system_tests --path .vendor
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Thu Nov 15 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.7.0-0
+- Fix warning about automatic data type munging in the puppet server sysconfig
+  template
+- Add workaround for Puppet 5 background exec issue to the generate_types exec
+
 * Mon Oct 29 2018 Chris Tessmer <chris.tessmer@onyxpoint.com> - 7.7.0-0
 - Remove deprecated `[master] ca` setting when `ca = true` in Puppet 5.5.6+
 - Remove `[master] ca` setting in Puppet 6+

--- a/manifests/master/generate_types.pp
+++ b/manifests/master/generate_types.pp
@@ -53,8 +53,7 @@ class pupmod::master::generate_types (
     }
 
     exec { 'simp_generate_types':
-      command     => "${_generate_types_path} -d ${delay} -p all &",
-      logoutput   => true,
+      command     => "${_generate_types_path} -d ${delay} -p all > /dev/null 2>&1 &",
       refreshonly => true
     }
 

--- a/templates/etc/sysconfig/puppetserver.epp
+++ b/templates/etc/sysconfig/puppetserver.epp
@@ -1,7 +1,7 @@
 <%
   # Variable Mangling #
   if $pupmod::master::sysconfig::java_max_memory[-1] == '%' {
-    $java_mem_mb = Integer($facts['memorysize_mb'] * ($pupmod::master::sysconfig::java_max_memory[0,-2]/100.0))
+    $java_mem_mb = Integer(Numeric($facts['memorysize_mb']) * (Numeric($pupmod::master::sysconfig::java_max_memory[0,-2])/100.00))
     $java_max_memory = "${java_mem_mb}m"
   }
 


### PR DESCRIPTION
- Fix warning about automatic data type munging in the puppet server
  sysconfig template
- Add workaround for Puppet 5 background exec issue to the
  generate_types exec

SIMP-5707 #close