### PR TITLE
(SIMP-5978) Temporarily disable generate_types

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Tue Jan 22 2019
+* Tue Jan 22 2019 Brandon Riden <brandon.riden@onyxpoint.com> - 7.7.1-0
 - Set pupmod::master::generate_types: enable => false by default to fix
   bug causing puppet servers to crash.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Jan 22 2019
+- Set pupmod::master::generate_types: enable => false by default to fix
+  bug causing puppet servers to crash.
+
 * Thu Nov 15 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.7.0-0
 - Fix warning about automatic data type munging in the puppet server sysconfig
   template

--- a/manifests/master/generate_types.pp
+++ b/manifests/master/generate_types.pp
@@ -26,7 +26,7 @@
 #   * Puppet Environment Paths
 #
 class pupmod::master::generate_types (
-  Boolean                     $enable                         = true,
+  Boolean                     $enable                         = false,
   Boolean                     $trigger_on_puppetserver_update = true,
   Boolean                     $trigger_on_puppet_update       = true,
   Integer[0]                  $delay                          = 30,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pupmod",
-  "version": "7.7.0",
+  "version": "7.7.1",
   "author": "SIMP Team",
   "summary": "A puppet module to manage puppetserver and puppet agents",
   "license": "Apache-2.0",

--- a/spec/classes/master/generate_types_spec.rb
+++ b/spec/classes/master/generate_types_spec.rb
@@ -18,6 +18,16 @@ describe 'pupmod::master::generate_types' do
       let(:facts){ os_facts }
 
       context 'with default input' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_file('/usr/local/sbin/simp_generate_types').with_ensure('absent') }
+        it { is_expected.not_to contain_exec('simp_generate_types') }
+        it { is_expected.to contain_incron__system_table('simp_generate_types').with_enable(false) }
+      end
+
+      context 'when enabling generate_types' do
+        let(:params){{
+            :enable => true
+        }}
         let(:valid_output){[
           '/opt/puppetlabs/server/apps/puppetserver/bin IN_MODIFY,IN_NO_LOOP /usr/local/sbin/simp_generate_types -p all -s -d 30',
           '/opt/puppetlabs/puppet/bin/puppet IN_MODIFY,IN_NO_LOOP /usr/local/sbin/simp_generate_types -p all -s -d 30',
@@ -29,8 +39,9 @@ describe 'pupmod::master::generate_types' do
         it_behaves_like 'generate_types tests'
       end
 
-      context 'when disabling puppetserver triggers' do
+      context 'when disabling puppetserver triggers with generate_types enabled' do
         let(:params){{
+          :enable => true,
           :trigger_on_puppetserver_update => false
         }}
 
@@ -44,8 +55,9 @@ describe 'pupmod::master::generate_types' do
         it_behaves_like 'generate_types tests'
       end
 
-      context 'when disabling puppet triggers' do
+      context 'when disabling puppet triggers with generate_types enabled' do
         let(:params){{
+          :enable => true,
           :trigger_on_puppet_update => false
         }}
 
@@ -59,7 +71,10 @@ describe 'pupmod::master::generate_types' do
         it_behaves_like 'generate_types tests'
       end
 
-      context 'with a split environmentpath input' do
+      context 'with a split environmentpath input with generate_types enabled' do
+        let(:params){{
+            :enable => true
+        }}
         let(:facts){
           os_facts.merge({
             :puppet_environmentpath => '/path/one:/path/two'
@@ -78,17 +93,6 @@ describe 'pupmod::master::generate_types' do
         ].join("\n")}
 
         it_behaves_like 'generate_types tests'
-      end
-
-      context 'when disabling generate_types' do
-        let(:params){{
-          :enable => false
-        }}
-
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_file('/usr/local/sbin/simp_generate_types').with_ensure('absent') }
-        it { is_expected.not_to contain_exec('simp_generate_types') }
-        it { is_expected.to contain_incron__system_table('simp_generate_types').with_enable(false) }
       end
     end
   end


### PR DESCRIPTION
Sets pupmod::master::generate_types: enable => false by default to fix
bug causing puppet servers to crash.

SIMP-5978 #comment temporary workaround for generate_types bug