### PR TITLE
(SIMP-6211) Fix dep cycle with inifile 2.5.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Wed Mar 06 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 7.8.1-0
+- Update minimum version of inifile Puppet module to 2.5.0
+- Fix dependency cycle in a full SIMP system that was introduced by
+  the new autorequire of the parent directory of an INI file in the
+  ini_setting type
+
 * Wed Feb 20 2019 Nick Miller <nick.miller@onyxpoint.com> - 7.8.1-0
 - Add management of $ssldir, $rundir, and /var/log/puppetserver
 

--- a/manifests/master/base.pp
+++ b/manifests/master/base.pp
@@ -53,7 +53,6 @@ class pupmod::master::base {
 
   package { $::pupmod::master::service:
     ensure => $::pupmod::master::package_ensure,
-    before => File[$::pupmod::confdir],
     notify => Service[$::pupmod::master::service]
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -27,7 +27,7 @@
     },
     {
       "name": "puppetlabs/inifile",
-      "version_requirement": ">= 1.6.0 < 3.0.0"
+      "version_requirement": ">= 2.5.0 < 3.0.0"
     },
     {
       "name": "puppetlabs/puppet_authorization",


### PR DESCRIPTION
- Update minimum version of inifile Puppet module to 2.5.0
- Fix dependency cycle in a full SIMP system that was introduced by
  the new autorequire of the parent directory of an INI file in the
  ini_setting type

SIMP-6211 #close