### PR TITLE
(SIMP-6213) Use latest concat in tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,11 +9,7 @@ fixtures:
     incron: https://github.com/simp/pupmod-simp-incron
     inifile: https://github.com/simp/puppetlabs-inifile
     iptables: https://github.com/simp/pupmod-simp-iptables
-    concat:
-      # master is beyond 4.1.1, but has breaking changes to
-      # how fragments are ordered (MODULES-6625)
-      repo: https://github.com/simp/puppetlabs-concat
-      ref: 4.1.1
+    concat: https://github.com/simp/puppetlabs-concat
     simplib: https://github.com/simp/pupmod-simp-simplib
     stdlib: https://github.com/simp/puppetlabs-stdlib
     pam: https://github.com/simp/pupmod-simp-pam
@@ -22,7 +18,7 @@ fixtures:
       ref: 0.3.0
     puppet_authorization:
       repo: https://github.com/simp/puppetlabs-puppet_authorization
-      ref: 0.4.0
+      ref: 0.5.0
 
     # Fixtures needed for the acceptance test
     augeasproviders_ssh: https://github.com/simp/augeasproviders_ssh

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,8 @@
 - Fix dependency cycle in a full SIMP system that was introduced by
   the new autorequire of the parent directory of an INI file in the
   ini_setting type
+- Expanded the upper limit of the concat and stdlib Puppet module versions
+- Updated a URL in the README.md
 
 * Wed Feb 20 2019 Nick Miller <nick.miller@onyxpoint.com> - 7.8.1-0
 - Add management of $ssldir, $rundir, and /var/log/puppetserver

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ a compliance-management framework built on Puppet.
 
 If you find any issues, they can be submitted to our [JIRA](https://simp-project.atlassian.net/).
 
-Please read our [Contribution Guide](http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
 
 ## Upgrading From 7.3.0 Or Earlier
 

--- a/metadata.json
+++ b/metadata.json
@@ -23,7 +23,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.19.0 < 5.0.0"
+      "version_requirement": ">= 4.19.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/inifile",
@@ -35,7 +35,7 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 3.0.0 < 6.0.0"
     },
     {
       "name": "simp/incron",


### PR DESCRIPTION
- Test with latest concat Puppet module instead of 4.1.1
- Test with 0.5 puppet_authorization Puppet module
- Expanded the upper limit of the concat and stdlib Puppet module versions
- Updated a URL in the README.md

SIMP-6213 #comment pupmod-simp-pupmod