### PR TITLE
Set JAVA_ARGS_CLI as well as JAVA_ARGS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,9 @@ addons:
 
 before_install:
   - rm -f Gemfile.lock
-  - gem install -v '~> 1.16' bundler
+  - gem install -v '~> 1.14' bundler
+  - gem uninstall -i /home/travis/.rvm/gems/ruby-2.4.4@global -v '>= 1.15' bundler || true
+  - gem uninstall -i /home/travis/.rvm/gems/ruby-2.5.1@global -v '>= 1.15' bundler || true
 
 global:
   - STRICT_VARIABLES=yes

--- a/manifests/master/sysconfig.pp
+++ b/manifests/master/sysconfig.pp
@@ -98,15 +98,17 @@ class pupmod::master::sysconfig (
     if ($server_distribution == 'PE') {
       if (has_key($facts, 'pe_build')) {
         if (SemVer($facts['pe_build']) < SemVer('2016.4.0')) {
-          pe_ini_subsetting { 'pupmod::master::sysconfig::javatempdir':
-            path              => '/etc/sysconfig/pe-puppetserver',
-            section           => '',
-            setting           => 'JAVA_ARGS',
-            subsetting        => '-Djava.io.tmpdir',
-            quote_char        => '"',
-            value             => "=${_java_temp_dir}",
-            key_val_separator => '=',
-            notify            => Service[$service],
+          ['JAVA_ARGS', 'JAVA_ARGS_CLI'].each |String $setting| {
+            pe_ini_subsetting { "pupmod::master::sysconfig::javatempdir for ${setting}":
+              path              => '/etc/sysconfig/pe-puppetserver',
+              section           => '',
+              setting           => $setting,
+              subsetting        => '-Djava.io.tmpdir',
+              quote_char        => '"',
+              value             => "=${_java_temp_dir}",
+              key_val_separator => '=',
+              notify            => Service[$service],
+            }
           }
         }
       }

--- a/spec/classes/master/data/puppetserver-j9.txt
+++ b/spec/classes/master/data/puppetserver-j9.txt
@@ -3,6 +3,7 @@ JAVA_BIN="/usr/bin/java"
 
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
 JAVA_ARGS="-Xms245m -Xmx245m -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp "
+JAVA_ARGS_CLI="-Xms245m -Xmx245m -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp "
 
 JRUBY_JAR="/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar"
 

--- a/spec/classes/master/data/puppetserver.txt
+++ b/spec/classes/master/data/puppetserver.txt
@@ -3,6 +3,7 @@ JAVA_BIN="/usr/bin/java"
 
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
 JAVA_ARGS="-Xms245m -Xmx245m -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp "
+JAVA_ARGS_CLI="-Xms245m -Xmx245m -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp "
 
 # These normally shouldn't need to be edited if using OS packages
 USER="puppet"

--- a/spec/classes/master/sysconfig_spec.rb
+++ b/spec/classes/master/sysconfig_spec.rb
@@ -42,10 +42,13 @@ describe 'pupmod::master::sysconfig' do
             }
 
             it 'sets $tmpdir via a pe_ini_subsetting resource' do
-              expect(catalogue).to contain_pe_ini_subsetting('pupmod::master::sysconfig::javatempdir').with(
-                'value' => %r{/pserver_tmp$},
-                'path'  => '/etc/sysconfig/pe-puppetserver',
-              )
+              ['JAVA_ARGS', 'JAVA_ARGS_CLI'].each do |setting|
+                expect(catalogue).to contain_pe_ini_subsetting("pupmod::master::sysconfig::javatempdir for #{setting}").with(
+                  'path'    => '/etc/sysconfig/pe-puppetserver',
+                  'setting' => setting,
+                  'value'   => %r{/pserver_tmp$},
+                )
+              end
             end
           else
             context 'on PC1 with default params' do

--- a/spec/defines/pass_two_spec.rb
+++ b/spec/defines/pass_two_spec.rb
@@ -209,10 +209,12 @@ describe 'pupmod::pass_two' do
                       let (:facts) do
                         { "pe_build" => pe_version }.merge(facts)
                       end
-                      if (tmpdir == true)
-                        it { is_expected.to contain_pe_ini_subsetting("pupmod::master::sysconfig::javatempdir")}
-                      else
-                        it { is_expected.to_not contain_pe_ini_subsetting("pupmod::master::sysconfig::javatempdir")}
+                      ['JAVA_ARGS', 'JAVA_ARGS_CLI'].each do |setting|
+                        if (tmpdir == true)
+                          it { is_expected.to contain_pe_ini_subsetting("pupmod::master::sysconfig::javatempdir for #{setting}")}
+                        else
+                          it { is_expected.to_not contain_pe_ini_subsetting("pupmod::master::sysconfig::javatempdir for #{setting}")}
+                        end
                       end
                     end
                   end

--- a/templates/etc/sysconfig/puppetserver.epp
+++ b/templates/etc/sysconfig/puppetserver.epp
@@ -24,6 +24,7 @@ JAVA_BIN="<%= $pupmod::master::sysconfig::java_bin %>"
 
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
 JAVA_ARGS="-Xms<%= $java_start_memory %> -Xmx<%= $java_max_memory %> -Djava.io.tmpdir=<%= $pupmod::master::sysconfig::_java_temp_dir %> <%= $extra_java_args %>"
+JAVA_ARGS_CLI="-Xms<%= $java_start_memory %> -Xmx<%= $java_max_memory %> -Djava.io.tmpdir=<%= $pupmod::master::sysconfig::_java_temp_dir %> <%= $extra_java_args %>"
 
 <% if $pupmod::master::sysconfig::_jruby_jar != 'default' { -%>
 JRUBY_JAR="<%= $pupmod::master::sysconfig::_jruby_jar %>"


### PR DESCRIPTION
This prevents the `flock unsupported or native support failed to load` error
when using `puppetserver gem install` with [`/tmp` mounted  `noexec`](https://puppet.com/docs/puppetserver/latest/known_issues.html#tmp-directory-mounted-noexec).