### PR TITLE
(SIMP-6629) puppet uid/gid wrong

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue May 28 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 7.10.1-0
+- No longer hardcode the puppet uid and puppet gid to 52.
+
 * Fri May 17 2019 Robert Vincent <robert.vincent@conning.com> - 7.10.1-0
 - Add missing gem-path setting to puppetserver.conf template.
 

--- a/manifests/master/base.pp
+++ b/manifests/master/base.pp
@@ -72,7 +72,6 @@ class pupmod::master::base {
     ensure     => 'present',
     allowdupe  => false,
     comment    => 'Puppet User',
-    uid        => '52',
     gid        => 'puppet',
     home       => $pupmod::master::vardir,
     membership => 'inclusive',

--- a/manifests/pass_two.pp
+++ b/manifests/pass_two.pp
@@ -108,7 +108,6 @@ define pupmod::pass_two (
   group { $_conf_group:
     ensure    => 'present',
     allowdupe => false,
-    gid       => '52',
     tag       => 'firstrun',
     notify    => $_group_notify,
     members   => $_group_members,

--- a/spec/classes/master/base_spec.rb
+++ b/spec/classes/master/base_spec.rb
@@ -65,7 +65,6 @@ describe 'pupmod::master::base' do
             {
               "ensure" => "present",
               "allowdupe" => false,
-              "gid" => "52",
               "tag" => "firstrun",
             }
           )
@@ -90,7 +89,6 @@ describe 'pupmod::master::base' do
               "ensure" => "present",
               "allowdupe" => false,
               "comment" => "Puppet User",
-              "uid" => "52",
               "gid" => "puppet",
               "home" => "/opt/puppetlabs/server/data/puppetserver",
               "membership" => "inclusive",

--- a/spec/defines/pass_two_spec.rb
+++ b/spec/defines/pass_two_spec.rb
@@ -84,7 +84,6 @@ describe 'pupmod::pass_two' do
               it { is_expected.to contain_group('puppet').with({
                 'ensure' => 'present',
                 'allowdupe'  => false,
-                'gid'  => '52',
                 'tag'   => 'firstrun',
               }) }
 


### PR DESCRIPTION
No longer hardcode the puppet uid and puppet gid to 52.

These ids are no longer set via SIMP asset RPM %post
actions.  If this module assumes ids of 52 in the resources it
creates for the puppet user and group, `simp bootstrap` fails.

SIMP-6629 #close