### PR TITLE
(SIMP-6814) Add ca params for auth-extensions and subject-alt-names.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Jun 28 2019 Bob Vincent <pillarsdotnet@gmail.com> - 7.10.2-0
+- Add ca params for auth-extensions and subject-alt-names.
+
 * Tue May 28 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 7.10.1-0
 - No longer hardcode the puppet uid and puppet gid to 52.
 

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -5,6 +5,12 @@
 # @param bind_address
 #   The IP address to which the Puppet Master process should bind
 #
+# @param ca_allow_auth_extensions
+#   If true, allows the CA to sign certificates with authorization extensions.
+#
+# @param ca_allow_alt_names
+#   If true, allows the CA to sign certificates with subject alternative names.
+#
 # @param ca_bind_address
 #   The IP address to which the Puppet CA process should bind
 #
@@ -256,6 +262,8 @@
 #
 class pupmod::master (
   Simplib::IP                                         $bind_address                    = '0.0.0.0',
+  Boolean                                             $ca_allow_auth_extensions        = false,
+  Boolean                                             $ca_allow_alt_names              = false,
   Simplib::IP                                         $ca_bind_address                 = '0.0.0.0',
   Boolean                                             $auditd                          = simplib::lookup('simp_options::auditd', { 'default_value' => false }),
   Simplib::Port                                       $ca_port                         = simplib::lookup('simp_options::puppet::ca_port', { 'default_value' => 8141 }),

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pupmod",
-  "version": "7.10.1",
+  "version": "7.10.2",
   "author": "SIMP Team",
   "summary": "A puppet module to manage puppetserver and puppet agents",
   "license": "Apache-2.0",

--- a/spec/classes/master_spec.rb
+++ b/spec/classes/master_spec.rb
@@ -592,7 +592,7 @@ describe 'pupmod::master' do
               it { expect(ca_conf_hash).to have_key('certificate-authority') }
               it { expect(ca_conf_hash['certificate-authority']).to have_key('allow-authorization-extensions') }
               it {
-                expect(ca_conf_hash['certificate-authority']['allow-authorization-extensions']).to have_value(true)
+                expect(ca_conf_hash['certificate-authority']['allow-authorization-extensions']).to be(true)
               }
             end
           end
@@ -616,7 +616,7 @@ describe 'pupmod::master' do
               it { expect(ca_conf_hash).to have_key('certificate-authority') }
               it { expect(ca_conf_hash['certificate-authority']).to have_key('allow-subject-alt-names') }
               it {
-                expect(ca_conf_hash['certificate-authority']['allow-subject-alt-names']).to have_value(true)
+                expect(ca_conf_hash['certificate-authority']['allow-subject-alt-names']).to be(true)
               }
             end
           end

--- a/spec/classes/master_spec.rb
+++ b/spec/classes/master_spec.rb
@@ -573,6 +573,54 @@ describe 'pupmod::master' do
           }) }
           end
 
+          context 'with ca_allow_auth_extensions' do
+            let(:params) {{:ca_allow_auth_extensions => true}}
+
+            context 'when processing ca.conf' do
+              let(:ca_conf) { '/etc/puppetlabs/puppetserver/conf.d/ca.conf' }
+              let(:ca_conf_hash) { Hocon.parse(catalogue.resource("File[#{ca_conf}]")['content']) }
+
+              it { is_expected.to contain_file('/etc/puppetlabs/puppetserver/conf.d/ca.conf').with({
+                'ensure'  => 'file',
+                'owner'   => 'root',
+                'group'   => 'puppet',
+                'mode'    => '0640',
+                'require' => 'Package[puppetserver]',
+                'notify'  => 'Service[puppetserver]'
+              }) }
+
+              it { expect(ca_conf_hash).to have_key('certificate-authority') }
+              it { expect(ca_conf_hash['certificate-authority']).to have_key('allow-authorization-extensions') }
+              it {
+                expect(ca_conf_hash['certificate-authority']['allow-authorization-extensions']).to have_value(true)
+              }
+            end
+          end
+
+          context 'with ca_allow_alt_names' do
+            let(:params) {{:ca_allow_alt_names => true}}
+
+            context 'when processing ca.conf' do
+              let(:ca_conf) { '/etc/puppetlabs/puppetserver/conf.d/ca.conf' }
+              let(:ca_conf_hash) { Hocon.parse(catalogue.resource("File[#{ca_conf}]")['content']) }
+
+              it { is_expected.to contain_file('/etc/puppetlabs/puppetserver/conf.d/ca.conf').with({
+                'ensure'  => 'file',
+                'owner'   => 'root',
+                'group'   => 'puppet',
+                'mode'    => '0640',
+                'require' => 'Package[puppetserver]',
+                'notify'  => 'Service[puppetserver]'
+              }) }
+
+              it { expect(ca_conf_hash).to have_key('certificate-authority') }
+              it { expect(ca_conf_hash['certificate-authority']).to have_key('allow-subject-alt-names') }
+              it {
+                expect(ca_conf_hash['certificate-authority']['allow-subject-alt-names']).to have_value(true)
+              }
+            end
+          end
+
           context 'with multiple entries in ca_status_whitelist' do
             let(:params) {{:ca_status_whitelist => ['1.2.3.4', '5.6.7.8']}}
 

--- a/templates/etc/puppetserver/conf.d/ca.conf.epp
+++ b/templates/etc/puppetserver/conf.d/ca.conf.epp
@@ -4,6 +4,13 @@
 # CA-related settings
 certificate-authority: {
 
+<% if $pupmod::master::ca_allow_auth_extensions { -%>
+    allow-authorization-extensions: true
+<% } -%>
+<% if $pupmod::master::ca_allow_alt_names { -%>
+    allow-subject-alt-names: true
+<% } -%>
+
     # settings for the certificate_status HTTP endpoint
     certificate-status: {
 


### PR DESCRIPTION
I need the subject-alt-names param to bootstrap a new puppetserver; the auth-extensions param is just for completeness.