### PR TITLE
Bug:  $java_max_memory is not defined

### DIFF
--- a/templates/etc/sysconfig/puppetserver.epp
+++ b/templates/etc/sysconfig/puppetserver.epp
@@ -4,6 +4,9 @@
     $java_mem_mb = Integer(Numeric($facts['memorysize_mb']) * (Numeric($pupmod::master::sysconfig::java_max_memory[0,-2])/100.00))
     $java_max_memory = "${java_mem_mb}m"
   }
+  else {
+    $java_max_memory = $pupmod::master::sysconfig::java_max_memory
+  }
 
   if $pupmod::master::sysconfig::java_start_memory {
     $java_start_memory = $pupmod::master::sysconfig::java_start_memory


### PR DESCRIPTION
If you pass a fixed ram size, $java_max_memory is undefined and you get an empty -Xmx argument
_JAVA_ARGS="-Xms16384m -Xmx -Djava.io.tmpdir=/opt/puppetlabs/server/data/puppetserver/pserver_tmp "