### PR TITLE
Fix ordering problems on first installation of puppetserver.

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -24,6 +24,9 @@ fixtures:
       # how fragments are ordered (MODULES-6625)
       repo: https://github.com/simp/puppetlabs-concat
       ref: 4.1.1
+    hocon:
+      repo: https://github.com/puppetlabs/puppetlabs-hocon
+      ref: 1.0.1
     logrotate: https://github.com/simp/pupmod-simp-logrotate
     pki: https://github.com/simp/pupmod-simp-pki
     rsyslog: https://github.com/simp/pupmod-simp-rsyslog

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,32 +58,132 @@ jobs:
         - bundle exec puppet module build
 
     - stage: spec
-      name: 'Puppet 5.3 (PE 2017.3)'
+      name: 'Puppet 5.3 (PE 2017.3) - Classes'
       rvm: 2.4.5
       env: PUPPET_VERSION="~> 5.3.0"
       script:
-        - bundle exec rake spec
+        - bundle exec rake spec_prep
+        - bundle exec rspec spec/classes
+
+    - stage: spec
+      name: 'Puppet 5.3 (PE 2017.3) - Defines'
+      rvm: 2.4.5
+      env: PUPPET_VERSION="~> 5.3.0"
+      script:
+        - bundle exec rake spec_prep
+        - bundle exec rspec spec/defines
+
+    - stage: spec
+      name: 'Puppet 5.3 (PE 2017.3) - Functions'
+      rvm: 2.4.5
+      env: PUPPET_VERSION="~> 5.3.0"
+      script:
+        - bundle exec rake spec_prep
+        - bundle exec rspec spec/functions
+
+    - stage: spec
+      name: 'Puppet 5.3 (PE 2017.3) - Unit'
+      rvm: 2.4.5
+      env: PUPPET_VERSION="~> 5.3.0"
+      script:
+        - bundle exec rake spec_prep
+        - bundle exec rspec spec/unit
 
     - stage: spec
       rvm: 2.4.5
-      name: 'Puppet 5.5 (SIMP 6.3, PE 2018.1)'
+      name: 'Puppet 5.5 (SIMP 6.3, PE 2018.1) - Classes'
       env: PUPPET_VERSION="~> 5.5.0"
       script:
-        - bundle exec rake spec
+        - bundle exec rake spec_prep
+        - bundle exec rspec spec/classes
 
     - stage: spec
-      name: 'Latest Puppet 5.x'
+      rvm: 2.4.5
+      name: 'Puppet 5.5 (SIMP 6.3, PE 2018.1) - Defines'
+      env: PUPPET_VERSION="~> 5.5.0"
+      script:
+        - bundle exec rake spec_prep
+        - bundle exec rspec spec/defines
+
+    - stage: spec
+      rvm: 2.4.5
+      name: 'Puppet 5.5 (SIMP 6.3, PE 2018.1) - Functions'
+      env: PUPPET_VERSION="~> 5.5.0"
+      script:
+        - bundle exec rake spec_prep
+        - bundle exec rspec spec/functions
+
+    - stage: spec
+      rvm: 2.4.5
+      name: 'Puppet 5.5 (SIMP 6.3, PE 2018.1) - Unit'
+      env: PUPPET_VERSION="~> 5.5.0"
+      script:
+        - bundle exec rake spec_prep
+        - bundle exec rspec spec/unit
+
+    - stage: spec
+      name: 'Latest Puppet 5.x - Classes'
       rvm: 2.4.5
       env: PUPPET_VERSION="~> 5.0"
       script:
-        - bundle exec rake spec
+        - bundle exec rake spec_prep
+        - bundle exec rspec spec/classes
 
     - stage: spec
-      name: 'Latest Puppet 6.x'
+      name: 'Latest Puppet 5.x - Defines'
+      rvm: 2.4.5
+      env: PUPPET_VERSION="~> 5.0"
+      script:
+        - bundle exec rake spec_prep
+        - bundle exec rspec spec/defines
+
+    - stage: spec
+      name: 'Latest Puppet 5.x - Functions'
+      rvm: 2.4.5
+      env: PUPPET_VERSION="~> 5.0"
+      script:
+        - bundle exec rake spec_prep
+        - bundle exec rspec spec/functions
+
+    - stage: spec
+      name: 'Latest Puppet 5.x - Unit'
+      rvm: 2.4.5
+      env: PUPPET_VERSION="~> 5.0"
+      script:
+        - bundle exec rake spec_prep
+        - bundle exec rspec spec/unit
+
+    - stage: spec
+      name: 'Latest Puppet 6.x - Classes'
       rvm: 2.5.1
       env: PUPPET_VERSION="~> 6.0"
       script:
-        - bundle exec rake spec
+        - bundle exec rake spec_prep
+        - bundle exec rspec spec/classes
+
+    - stage: spec
+      name: 'Latest Puppet 6.x - Defines'
+      rvm: 2.5.1
+      env: PUPPET_VERSION="~> 6.0"
+      script:
+        - bundle exec rake spec_prep
+        - bundle exec rspec spec/defines
+
+    - stage: spec
+      name: 'Latest Puppet 6.x - Functions'
+      rvm: 2.5.1
+      env: PUPPET_VERSION="~> 6.0"
+      script:
+        - bundle exec rake spec_prep
+        - bundle exec rspec spec/functions
+
+    - stage: spec
+      name: 'Latest Puppet 6.x - Unit'
+      rvm: 2.5.1
+      env: PUPPET_VERSION="~> 6.0"
+      script:
+        - bundle exec rake spec_prep
+        - bundle exec rspec spec/unit
 
     - stage: deploy
       rvm: 2.4.5

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+* Thu Jul 04 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.11.0-0
+- Add a pupmod::server_distribution function for more accurately determining
+  the version of the puppet server installed on the target system.
+- Refactor some of the underlying code to use the new function and be safer for
+  PE installations.
+
+* Thu Jul 01 2019 Bob Vincent <pillarsdotnet@gmail.com> - 7.11.0-0
+- Fix ordering issues with managing the Puppet Server
+
 * Fri Jun 28 2019 Steven Pritchard <steven.pritchard@onypoint.com> - 7.11.0-0
 - Add v2 compliance_markup data
 

--- a/functions/server_distribution.pp
+++ b/functions/server_distribution.pp
@@ -1,0 +1,31 @@
+# Figure out if we're running PC1 or PE puppet
+#
+# @param lookup_from_pupmod
+#   Attempt to look up the value from `$pupmod::server_distribution`
+#
+# @return [String]
+#   'PE' or 'PC1' as applicable
+#
+function pupmod::server_distribution (
+  Boolean $lookup_from_pupmod = true
+){
+
+  # Figure out what we think we have
+  if fact('pe_build') or (fact('puppet_settings.master.user') == 'pe-puppet') {
+    $server_type = 'PE'
+  }
+  else {
+    if $lookup_from_pupmod {
+      # Just in case someone set these to what they *want* it to be:
+      $server_type = pick(
+        getvar('pupmod::server_distribution'),
+        simplib::lookup('simp_options::puppet::server_distribution', { 'default_value' => 'PC1' })
+      )
+    }
+    else {
+      $server_type = simplib::lookup('simp_options::puppet::server_distribution', { 'default_value' => 'PC1' })
+    }
+  }
+
+  $server_type
+}

--- a/manifests/agent/cron.pp
+++ b/manifests/agent/cron.pp
@@ -134,8 +134,7 @@ class pupmod::agent::cron (
   Boolean                                 $break_puppet_lock  = true,
   Optional[Integer[1]]                    $max_disable_time   = undef
 ) {
-
-  include '::pupmod'
+  include 'pupmod'
 
   cron { 'puppetd': ensure => 'absent' }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -143,7 +143,7 @@ class pupmod (
   Variant[Simplib::Host,Enum['$server']] $ca_server            = simplib::lookup('simp_options::puppet::ca', { 'default_value' => '$server' }),
   Simplib::Port                          $ca_port              = simplib::lookup('simp_options::puppet::ca_port', { 'default_value' => 8141 }),
   Simplib::Host                          $puppet_server        = simplib::lookup('simp_options::puppet::server', { 'default_value' => "puppet.${facts['domain']}" }),
-  Simplib::ServerDistribution            $server_distribution  = simplib::lookup('simp_options::puppet::server_distribution', { 'default_value' => 'PC1' } ),
+  Simplib::ServerDistribution            $server_distribution  = pupmod::server_distribution(false), # Can't self-reference in this lookup
   Optional                               $ca_crl_pull_interval = undef,
   Simplib::Host                          $certname             = $facts['fqdn'],
   String[0]                              $classfile            = '$vardir/classes.txt',

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -333,7 +333,9 @@ class pupmod::master (
     include '::pupmod::master::base'
     include '::pupmod::master::generate_types'
 
-    Class['::pupmod::master::generate_types'] -> Service[$service]
+    Service[$service] -> Class['::pupmod::master::generate_types']
+    Service[$service] -> Exec['puppetserver_reload']
+    Service[$service] ~> Exec <| title == 'simp_generate_types' |>
     Class['::pupmod::master::sysconfig'] ~> Service[$service]
 
     $_conf_base = dirname($confdir)

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -268,7 +268,7 @@ class pupmod::master (
   Boolean                                             $auditd                          = simplib::lookup('simp_options::auditd', { 'default_value' => false }),
   Simplib::Port                                       $ca_port                         = simplib::lookup('simp_options::puppet::ca_port', { 'default_value' => 8141 }),
   Simplib::NetList                                    $trusted_nets                    = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1','::1'] }),
-  String                                              $server_distribution             = simplib::lookup('simp_options::puppet::server_distribution', { 'default_value' => 'PC1' } ),
+  String                                              $server_distribution             = pupmod::server_distribution(),
   Pupmod::CaTTL                                       $ca_ttl                          = '10y',
   Boolean                                             $daemonize                       = true,
   Boolean                                             $enable_ca                       = true,

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -333,7 +333,7 @@ class pupmod::master (
     include '::pupmod::master::base'
     include '::pupmod::master::generate_types'
 
-    Service[$service] -> Class['::pupmod::master::generate_types']
+    Service[$service] ~> Class['::pupmod::master::generate_types']
     Service[$service] -> Exec['puppetserver_reload']
     Service[$service] ~> Exec <| title == 'simp_generate_types' |>
     Class['::pupmod::master::sysconfig'] ~> Service[$service]

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -335,7 +335,6 @@ class pupmod::master (
 
     Service[$service] ~> Class['::pupmod::master::generate_types']
     Service[$service] -> Exec['puppetserver_reload']
-    Service[$service] ~> Exec <| title == 'simp_generate_types' |>
     Class['::pupmod::master::sysconfig'] ~> Service[$service]
 
     $_conf_base = dirname($confdir)

--- a/manifests/master/autosign.pp
+++ b/manifests/master/autosign.pp
@@ -12,7 +12,6 @@
 define pupmod::master::autosign (
   Optional[Pattern['^(\*\.)?\S+$']] $entry = undef
 ) {
-
   include 'pupmod::master'
 
   ensure_resource('concat', "${pupmod::confdir}/autosign.conf", {
@@ -20,7 +19,7 @@ define pupmod::master::autosign (
     'owner'  => 'root',
     'group'  => $facts['puppet_settings']['master']['group'],
     'mode'   => '0640',
-    'notify' => Service[$::pupmod::master::service]
+    'notify' => Class['pupmod::master::service']
   })
 
   if $entry {

--- a/manifests/master/base.pp
+++ b/manifests/master/base.pp
@@ -1,21 +1,20 @@
-# A break out of the mostly static files used by the Puppet master.
-#
-# @author Trevor Vaughan <tvaughan@onyxpoint.com>
+# @summary A break out of the mostly static files used by the Puppet master.
 #
 class pupmod::master::base {
-  include '::pupmod::master'
+  include 'pupmod::master'
+  include 'pupmod::master::install'
+  include 'pupmod::master::service'
+
+  Class['pupmod::master::install'] ~> Class['pupmod::master::service']
 
   exec { 'puppetserver_reload':
     command     => '/usr/local/sbin/puppetserver_reload',
     refreshonly => true,
+    subscribe   => Class['pupmod::master::service'],
     require     => File['/usr/local/sbin/puppetserver_reload']
   }
 
-  file { "${::pupmod::ssldir}/ca/ca_crl.pem":
-    notify => Service[$::pupmod::master::service]
-  }
-
-  file { $::pupmod::master::environmentpath:
+  file { $pupmod::master::environmentpath:
     ensure       => 'directory',
     owner        => 'root',
     group        => $facts['puppet_settings']['master']['group'],
@@ -33,7 +32,8 @@ class pupmod::master::base {
     content => epp("${module_name}/usr/local/sbin/puppetserver_clear_environment_cache", {
       'masterport'           => $pupmod::master::masterport,
       'admin_api_mountpoint' => $pupmod::master::admin_api_mountpoint
-      })
+      }
+    )
   }
 
   $_puppetserver_reload_cmd = @(END)
@@ -51,28 +51,10 @@ class pupmod::master::base {
     content => $_puppetserver_reload_cmd
   }
 
-  package { $::pupmod::master::service:
-    ensure => $::pupmod::master::package_ensure,
-    notify => Service[$::pupmod::master::service]
-  }
-
   $auth_conf = '/etc/puppetlabs/puppetserver/conf.d/auth.conf'
 
   puppet_authorization { $auth_conf:
     version => 1,
-  }
-
-  service { $::pupmod::master::service:
-    ensure     => 'running',
-    enable     => true,
-    hasrestart => true,
-    hasstatus  => true,
-    require    => [
-      Package[$::pupmod::master::service],
-      Group['puppet'],
-      Class['pupmod::master::sysconfig'],
-      Puppet_authorization[$auth_conf],
-    ]
   }
 
   user { 'puppet':
@@ -81,9 +63,8 @@ class pupmod::master::base {
     comment    => 'Puppet User',
     gid        => 'puppet',
     home       => $pupmod::master::vardir,
-    membership => 'inclusive',
     shell      => '/sbin/nologin',
     tag        => 'firstrun',
-    require    => Package[$::pupmod::master::service]
+    require    => Class['pupmod::master::install']
   }
 }

--- a/manifests/master/base.pp
+++ b/manifests/master/base.pp
@@ -56,6 +56,12 @@ class pupmod::master::base {
     notify => Service[$::pupmod::master::service]
   }
 
+  $auth_conf = '/etc/puppetlabs/puppetserver/conf.d/auth.conf'
+
+  puppet_authorization { $auth_conf:
+    version => 1,
+  }
+
   service { $::pupmod::master::service:
     ensure     => 'running',
     enable     => true,
@@ -64,7 +70,8 @@ class pupmod::master::base {
     require    => [
       Package[$::pupmod::master::service],
       Group['puppet'],
-      Class['pupmod::master::sysconfig']
+      Class['pupmod::master::sysconfig'],
+      Puppet_authorization[$auth_conf],
     ]
   }
 

--- a/manifests/master/fileserver_entry.pp
+++ b/manifests/master/fileserver_entry.pp
@@ -1,4 +1,4 @@
-# Manage entries in the /etc/puppet/fileserver.conf file.
+# @summary Manage entries in the /etc/puppet/fileserver.conf file.
 #
 # @param name
 #   The name of the [] segment.
@@ -8,8 +8,6 @@
 #
 # @param path
 #   The filesystem path to which this segment should point.
-#
-# @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 define pupmod::master::fileserver_entry (
   Variant[Array[Simplib::Host],Simplib::Host] $allow,
@@ -22,7 +20,7 @@ define pupmod::master::fileserver_entry (
     'owner'  => 'root',
     'group'  => $facts['puppet_settings']['master']['group'],
     'mode'   => '0640',
-    'notify' => Service[$::pupmod::master::service]
+    'notify' => Class['pupmod::master::service']
   })
 
   concat::fragment { "pupmod::master::fileserver_entry ${name}":

--- a/manifests/master/generate_types.pp
+++ b/manifests/master/generate_types.pp
@@ -94,8 +94,7 @@ class pupmod::master::generate_types (
     exec { 'simp_generate_types':
       command     => "${_generate_types_path} -d ${delay} -s -p all",
       refreshonly => true,
-      subscribe   => File[$_generate_types_path],
-      require     => File[$run_dir]
+      require     => File[$run_dir, $_generate_types_path],
     }
   }
 

--- a/manifests/master/generate_types.pp
+++ b/manifests/master/generate_types.pp
@@ -94,7 +94,8 @@ class pupmod::master::generate_types (
     exec { 'simp_generate_types':
       command     => "${_generate_types_path} -d ${delay} -s -p all",
       refreshonly => true,
-      require     => File[$run_dir, $_generate_types_path],
+      require     => File[$run_dir],
+      subscribe   => File[$_generate_types_path],
     }
   }
 

--- a/manifests/master/install.pp
+++ b/manifests/master/install.pp
@@ -1,0 +1,12 @@
+# @summary Install the puppetserver
+#
+class pupmod::master::install(
+  String[1] $package_name = simplib::lookup('simp_options::puppet::server_distribution', { 'default_value' => 'PC1' }) ? { 'PE' => 'pe-puppetserver', default => 'puppetserver'},
+  String[1] $package_ensure = pick(getvar('pupmod::master::package_ensure'), 'installed')
+) {
+  assert_private()
+
+  package { $package_name:
+    ensure => $package_ensure
+  }
+}

--- a/manifests/master/install.pp
+++ b/manifests/master/install.pp
@@ -1,12 +1,14 @@
 # @summary Install the puppetserver
 #
 class pupmod::master::install(
-  String[1] $package_name = simplib::lookup('simp_options::puppet::server_distribution', { 'default_value' => 'PC1' }) ? { 'PE' => 'pe-puppetserver', default => 'puppetserver'},
+  String[1] $package_name = pupmod::server_distribution() ? { 'PE' => 'pe-puppetserver', default => 'puppetserver'},
   String[1] $package_ensure = pick(getvar('pupmod::master::package_ensure'), 'installed')
 ) {
   assert_private()
 
-  package { $package_name:
-    ensure => $package_ensure
+  if pupmod::server_distribution() != 'PE' {
+    package { $package_name:
+      ensure => $package_ensure
+    }
   }
 }

--- a/manifests/master/service.pp
+++ b/manifests/master/service.pp
@@ -1,0 +1,14 @@
+# Split out the 'service' for cleaner dependency ordering
+#
+# @author Trevor Vaughan <tvaughan@onyxpoint.com>
+#
+class pupmod::master::service(
+  String[1] $service_name = simplib::lookup('simp_options::puppet::server_distribution', { 'default_value' => 'PC1' }) ? { 'PE' => 'pe-puppetserver', default => 'puppetserver'}
+) {
+  service { $service_name:
+    ensure     => 'running',
+    enable     => true,
+    hasrestart => true,
+    hasstatus  => true
+  }
+}

--- a/manifests/master/service.pp
+++ b/manifests/master/service.pp
@@ -3,12 +3,16 @@
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class pupmod::master::service(
-  String[1] $service_name = simplib::lookup('simp_options::puppet::server_distribution', { 'default_value' => 'PC1' }) ? { 'PE' => 'pe-puppetserver', default => 'puppetserver'}
+  String[1] $service_name = pupmod::server_distribution() ? { 'PE' => 'pe-puppetserver', default => 'puppetserver' }
 ) {
-  service { $service_name:
-    ensure     => 'running',
-    enable     => true,
-    hasrestart => true,
-    hasstatus  => true
+
+  if pupmod::server_distribution() != 'PE' {
+    service { 'Puppet Server':
+      name       => $service_name,
+      ensure     => 'running',
+      enable     => true,
+      hasrestart => true,
+      hasstatus  => true
+    }
   }
 }

--- a/manifests/master/service.pp
+++ b/manifests/master/service.pp
@@ -7,8 +7,7 @@ class pupmod::master::service(
 ) {
 
   if pupmod::server_distribution() != 'PE' {
-    service { 'Puppet Server':
-      name       => $service_name,
+    service { $service_name:
       ensure     => 'running',
       enable     => true,
       hasrestart => true,

--- a/manifests/master/simp_auth.pp
+++ b/manifests/master/simp_auth.pp
@@ -56,7 +56,7 @@
 #
 #
 class pupmod::master::simp_auth (
-  Simplib::ServerDistribution $server_distribution          = simplib::lookup('simp_options::puppet::server_distribution', { 'default_value' => 'PC1' } ),
+  Simplib::ServerDistribution $server_distribution          = pupmod::server_distribution(),
   Stdlib::AbsolutePath        $auth_conf_path               = '/etc/puppetlabs/puppetserver/conf.d/auth.conf',
   Boolean                     $legacy_cacerts_all           = false,
   Boolean                     $legacy_mcollective_all       = false,

--- a/manifests/master/simp_auth.pp
+++ b/manifests/master/simp_auth.pp
@@ -4,7 +4,7 @@
 # @see https://puppet.com/docs/puppetserver/2.7/config_file_auth.html#rules
 #
 # @param server_distribution
-#   The server distribution that is being managed.
+#   Deprecated: The server distribution that is being managed.
 #
 # @param auth_conf_path
 #   The location to the puppet master's auth.conf
@@ -56,29 +56,26 @@
 #
 #
 class pupmod::master::simp_auth (
-  Simplib::ServerDistribution $server_distribution          = pupmod::server_distribution(),
-  Stdlib::AbsolutePath        $auth_conf_path               = '/etc/puppetlabs/puppetserver/conf.d/auth.conf',
-  Boolean                     $legacy_cacerts_all           = false,
-  Boolean                     $legacy_mcollective_all       = false,
-  Boolean                     $legacy_pki_keytabs_from_host = false,
-  Boolean                     $pki_mcollective_all          = true,
-  Boolean                     $pki_cacerts_all              = true,
-  NotUndef                    $pki_cacerts_all_rule         = '^/puppet/v3/file_(metadata|content)/modules/pki_files/keydist/cacerts',
-  NotUndef                    $pki_cacerts_all_allow        = '*',
-  Any                         $pki_cacerts_all_deny         = undef,
-  Boolean                     $keydist_from_host            = true,
-  NotUndef                    $keydist_from_host_rule       = '^/puppet/v3/file_(metadata|content)/modules/pki_files/keydist/([^/]+)',
-  NotUndef                    $keydist_from_host_allow      = '$2',
-  Any                         $keydist_from_host_deny       = undef,
-  Boolean                     $krb5_keytabs_from_host       = true,
-  NotUndef                    $krb5_keytabs_from_host_rule  = '^/puppet/v3/file_(metadata|content)/modules/krb5_files/keytabs/([^/]+)',
-  NotUndef                    $krb5_keytabs_from_host_allow = '$2',
-  Any                         $krb5_keytabs_from_host_deny  = undef,
+  Optional[Simplib::ServerDistribution] $server_distribution          = undef,
+  Stdlib::AbsolutePath                  $auth_conf_path               = '/etc/puppetlabs/puppetserver/conf.d/auth.conf',
+  Boolean                               $legacy_cacerts_all           = false,
+  Boolean                               $legacy_mcollective_all       = false,
+  Boolean                               $legacy_pki_keytabs_from_host = false,
+  Boolean                               $pki_mcollective_all          = true,
+  Boolean                               $pki_cacerts_all              = true,
+  NotUndef                              $pki_cacerts_all_rule         = '^/puppet/v3/file_(metadata|content)/modules/pki_files/keydist/cacerts',
+  NotUndef                              $pki_cacerts_all_allow        = '*',
+  Any                                   $pki_cacerts_all_deny         = undef,
+  Boolean                               $keydist_from_host            = true,
+  NotUndef                              $keydist_from_host_rule       = '^/puppet/v3/file_(metadata|content)/modules/pki_files/keydist/([^/]+)',
+  NotUndef                              $keydist_from_host_allow      = '$2',
+  Any                                   $keydist_from_host_deny       = undef,
+  Boolean                               $krb5_keytabs_from_host       = true,
+  NotUndef                              $krb5_keytabs_from_host_rule  = '^/puppet/v3/file_(metadata|content)/modules/krb5_files/keytabs/([^/]+)',
+  NotUndef                              $krb5_keytabs_from_host_allow = '$2',
+  Any                                   $krb5_keytabs_from_host_deny  = undef,
 ) {
-  $_master_service = $server_distribution ? {
-    'PE'    => 'pe-puppetserver',
-    default => 'puppetserver',
-  }
+  include 'pupmod::master::service'
 
   # translates the parameter, which is a boolean, to the ensure parameter for the define
   $bool2ensure = {
@@ -101,7 +98,7 @@ class pupmod::master::simp_auth (
     allow                => '*',
     sort_order           => 400,
     path                 => $auth_conf_path,
-    notify               => Service[$_master_service],
+    notify               => Class['pupmod::master::service']
   }
 
   puppet_authorization::rule { 'Allow access to the mcollective cacerts from the legacy pki module from all hosts':
@@ -112,7 +109,7 @@ class pupmod::master::simp_auth (
     allow                => '*',
     sort_order           => 420,
     path                 => $auth_conf_path,
-    notify               => Service[$_master_service],
+    notify               => Class['pupmod::master::service']
   }
 
 
@@ -124,7 +121,7 @@ class pupmod::master::simp_auth (
     allow                => '$2',
     sort_order           => 450,
     path                 => $auth_conf_path,
-    notify               => Service[$_master_service],
+    notify               => Class['pupmod::master::service']
   }
 
   puppet_authorization::rule { 'Allow access to the mcollective PKI from the pki_files module from all hosts':
@@ -135,7 +132,7 @@ class pupmod::master::simp_auth (
     allow                => '*',
     sort_order           => 430,
     path                 => $auth_conf_path,
-    notify               => Service[$_master_service],
+    notify               => Class['pupmod::master::service']
   }
 
   puppet_authorization::rule { 'Allow access to the cacerts from the pki_files module from all hosts':
@@ -147,7 +144,7 @@ class pupmod::master::simp_auth (
     deny                 => $pki_cacerts_all_deny,
     sort_order           => 410,
     path                 => $auth_conf_path,
-    notify               => Service[$_master_service],
+    notify               => Class['pupmod::master::service']
   }
 
   puppet_authorization::rule { 'Allow access to each hosts own certs from the pki_files module':
@@ -159,7 +156,7 @@ class pupmod::master::simp_auth (
     deny                 => $keydist_from_host_deny,
     sort_order           => 440,
     path                 => $auth_conf_path,
-    notify               => Service[$_master_service],
+    notify               => Class['pupmod::master::service']
   }
 
   puppet_authorization::rule { 'Allow access to each hosts own kerberos keytabs from the krb5_files module':
@@ -171,7 +168,7 @@ class pupmod::master::simp_auth (
     deny                 => $krb5_keytabs_from_host_deny,
     sort_order           => 460,
     path                 => $auth_conf_path,
-    notify               => Service[$_master_service],
+    notify               => Class['pupmod::master::service']
   }
 
   # The puppet-agent package drops off this file for some reason, and it comes
@@ -181,6 +178,6 @@ class pupmod::master::simp_auth (
   file { '/etc/puppetlabs/puppet/auth.conf':
     ensure => absent,
     backup => true,
-    notify => Service[$_master_service]
+    notify => Class['pupmod::master::service']
   }
 }

--- a/manifests/master/sysconfig.pp
+++ b/manifests/master/sysconfig.pp
@@ -68,7 +68,7 @@ class pupmod::master::sysconfig (
   Optional[Array[String]]        $extra_java_args      = undef,
   Integer                        $service_stop_retries = 60,
   Integer                        $start_timeout        = 120,
-  Simplib::ServerDistribution    $server_distribution  = 'PC1',
+  Simplib::ServerDistribution    $server_distribution  = pupmod::server_distribution(),
   String                         $user                 = $facts['puppet_settings']['master']['user'],
   String                         $group                = $facts['puppet_settings']['master']['group'],
   Boolean                        $mock                 = false

--- a/manifests/pass_two.pp
+++ b/manifests/pass_two.pp
@@ -1,5 +1,7 @@
-# A helper defined type for adding processing to fix some issues with Puppet 4+
-# installations.
+# @summary A helper defined type for adding processing to fix some issues with
+# Puppet 4+ installations.
+#
+# @private
 #
 # @param namevar
 # @param server_distribution
@@ -16,7 +18,7 @@
 #
 define pupmod::pass_two (
   String                                 $namevar             = $name,
-  Simplib::ServerDistribution            $server_distribution = 'PC1',
+  Simplib::ServerDistribution            $server_distribution = pupmod::server_distribution(),
   Stdlib::AbsolutePath                   $confdir             = '/etc/puppetlabs/puppet',
   Optional[Boolean]                      $firewall            = undef,
   Hash                                   $pe_classlist        = lookup('pupmod::pe_classlist'),
@@ -26,6 +28,8 @@ define pupmod::pass_two (
   Boolean                                $pupmod_report       = false,
   Simplib::Port                          $pupmod_masterport   = 8140,
 ) {
+  assert_private()
+
   if (defined(Class['puppet_enterprise'])) {
     $_server_distribution = 'PE'
   } else {
@@ -124,11 +128,7 @@ define pupmod::pass_two (
     if (defined(Class['pupmod::master'])) {
       fail('pupmod::master is NOT supported on PE masters. Please remove the pupmod::master classification from hiera or the puppet console before proceeding')
     } else {
-      class { 'pupmod::master::sysconfig':
-        server_distribution => 'PE',
-        service             => 'pe-puppetserver',
-        user                => 'pe-puppet',
-      }
+      include 'pupmod::master::sysconfig'
     }
   }
   if (defined(Class['pupmod::master'])) {

--- a/metadata.json
+++ b/metadata.json
@@ -23,7 +23,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.19.0 < 6.0.0"
+      "version_requirement": ">= 4.19.0 < 7.0.0"
     },
     {
       "name": "puppetlabs/inifile",

--- a/metadata.json
+++ b/metadata.json
@@ -34,6 +34,10 @@
       "version_requirement": ">= 0.2.0 < 1.0.0"
     },
     {
+      "name": "puppetlabs/hocon",
+      "version_requirement": ">= 0.9.3 < 2.0.0"
+    },
+    {
       "name": "puppetlabs/concat",
       "version_requirement": ">= 3.0.0 < 6.0.0"
     },

--- a/spec/acceptance/suites/default/01_puppet_server_spec.rb
+++ b/spec/acceptance/suites/default/01_puppet_server_spec.rb
@@ -51,8 +51,6 @@ describe 'install environment via r10k and puppetserver' do
 
       it 'should apply the master manifest' do
         apply_manifest_on(master, master_manifest, :accept_all_exit_codes => true)
-        # Work around incron bug
-        apply_manifest_on(master, master_manifest, :accept_all_exit_codes => true)
       end
 
       it 'should be idempotent' do

--- a/spec/classes/master/base_spec.rb
+++ b/spec/classes/master/base_spec.rb
@@ -21,7 +21,6 @@ describe 'pupmod::master::base' do
             }
           )
         }
-        it { is_expected.to contain_file('/etc/puppetlabs/puppet/ssl/ca/ca_crl.pem') }
         it { is_expected.to contain_file('/etc/puppetlabs/code/environments').with(
             {
               "ensure" => "directory",
@@ -91,7 +90,6 @@ describe 'pupmod::master::base' do
               "comment" => "Puppet User",
               "gid" => "puppet",
               "home" => "/opt/puppetlabs/server/data/puppetserver",
-              "membership" => "inclusive",
               "shell" => "/sbin/nologin",
               "tag" => "firstrun",
             }

--- a/spec/classes/master/generate_types_spec.rb
+++ b/spec/classes/master/generate_types_spec.rb
@@ -5,7 +5,7 @@ describe 'pupmod::master::generate_types' do
     it { is_expected.to compile.with_all_deps }
     it { is_expected.to create_file('/usr/local/sbin/simp_generate_types') }
     it { is_expected.to create_file('/var/run/simp_generate_types') }
-    it { is_expected.to create_exec('simp_generate_types').that_subscribes_to('File[/usr/local/sbin/simp_generate_types]') }
+    it { is_expected.to create_exec('simp_generate_types').that_requires('File[/usr/local/sbin/simp_generate_types]') }
     it { is_expected.to create_exec('simp_generate_types').that_requires('File[/var/run/simp_generate_types]') }
     it { is_expected.to create_incron__system_table('simp_generate_types').that_requires('File[/usr/local/sbin/simp_generate_types]') }
     it { is_expected.to create_incron__system_table('simp_generate_types').that_requires('File[/var/run/simp_generate_types]') }

--- a/spec/classes/master/simp_auth_spec.rb
+++ b/spec/classes/master/simp_auth_spec.rb
@@ -7,20 +7,6 @@ describe 'pupmod::master::simp_auth' do
 
       ['PE', 'PC1'].each do |server_distribution|
         context "server distribution '#{server_distribution}'" do
-          let(:puppetserver_svc) {
-            svc = 'puppetserver'
-
-            if server_distribution == 'PE'
-              svc = 'pe-puppetserver'
-            end
-
-            svc
-          }
-
-          let(:pre_condition) {
-            %{ service{ #{puppetserver_svc}: } }
-          }
-
           let(:params) {{
             :server_distribution => server_distribution
           }}
@@ -83,7 +69,7 @@ describe 'pupmod::master::simp_auth' do
             'match_request_method' => ['get'],
             'allow'                => '$2',
             'sort_order'           => 460,
-            'notify'               => "Service[#{puppetserver_svc}]"
+            'notify'               => "Class[Pupmod::Master::Service]"
           }) }
           it { is_expected.to create_file('/etc/puppetlabs/puppet/auth.conf').with_ensure('absent') }
         end

--- a/spec/classes/master/sysconfig_spec.rb
+++ b/spec/classes/master/sysconfig_spec.rb
@@ -24,10 +24,6 @@ describe 'pupmod::master::sysconfig' do
             svc
           }
 
-          let(:pre_condition) {
-            %{ service{ #{puppetserver_svc}: } }
-          }
-
           let(:default_params){{
             :server_distribution => server_distribution
           }}

--- a/spec/classes/master_spec.rb
+++ b/spec/classes/master_spec.rb
@@ -44,7 +44,7 @@ describe 'pupmod::master' do
           it { is_expected.to create_class('pupmod::master::sysconfig') }
           it { is_expected.to create_class('pupmod::master::reports') }
           it { is_expected.to create_class('pupmod::master::base') }
-          it { is_expected.to contain_class('pupmod::master::sysconfig').that_comes_before('Service[puppetserver]') }
+          it { is_expected.to contain_class('pupmod::master::sysconfig').that_comes_before('Class[Pupmod::Master::Service]') }
           it { is_expected.to contain_file('/etc/puppetlabs/puppetserver').with({
             'ensure' => 'directory',
             'owner'  => 'root',
@@ -83,8 +83,8 @@ describe 'pupmod::master' do
             'owner'   => 'root',
             'group'   => 'puppet',
             'mode'    => '0640',
-            'require' => 'Package[puppetserver]',
-            'notify'  => 'Service[puppetserver]'
+            'require' => 'Class[Pupmod::Master::Install]',
+            'notify'  => 'Class[Pupmod::Master::Service]'
           }) }
 
           if puppetserver_version >= '5.1.0'
@@ -103,8 +103,8 @@ describe 'pupmod::master' do
             'owner'   => 'root',
             'group'   => 'puppet',
             'mode'    => '0640',
-            'require' => 'Package[puppetserver]',
-            'notify'  => 'Service[puppetserver]',
+            'require' => 'Class[Pupmod::Master::Install]',
+            'notify'  => 'Class[Pupmod::Master::Service]',
             'content' => %q~<!--
   This file managed by Puppet.
   Any changes will be erased at the next run.
@@ -148,8 +148,8 @@ describe 'pupmod::master' do
               'owner'   => 'root',
               'group'   => 'puppet',
               'mode'    => '0640',
-              'require' => 'Package[puppetserver]',
-              'notify'  => 'Service[puppetserver]'
+              'require' => 'Class[Pupmod::Master::Install]',
+              'notify'  => 'Class[Pupmod::Master::Service]'
             }) }
 
             it { expect(ca_conf_hash).to have_key('certificate-authority') }
@@ -174,8 +174,8 @@ describe 'pupmod::master' do
               'owner'   => 'root',
               'group'   => 'puppet',
               'mode'    => '0640',
-              'require' => 'Package[puppetserver]',
-              'notify'  => 'Service[puppetserver]'
+              'require' => 'Class[Pupmod::Master::Install]',
+              'notify'  => 'Class[Pupmod::Master::Service]'
             }) }
 
             it { expect(puppetserver_conf_hash).to have_key('jruby-puppet') }
@@ -246,8 +246,8 @@ describe 'pupmod::master' do
               'owner'   => 'root',
               'group'   => 'puppet',
               'mode'    => '0640',
-              'require' => 'Package[puppetserver]',
-              'notify'  => 'Service[puppetserver]'
+              'require' => 'Class[Pupmod::Master::Install]',
+              'notify'  => 'Class[Pupmod::Master::Service]'
             }) }
 
             it { expect(web_routes_conf_hash).to have_key('web-router-service') }
@@ -283,8 +283,8 @@ describe 'pupmod::master' do
               'owner'   => 'root',
               'group'   => 'puppet',
               'mode'    => '0640',
-              'require' => 'Package[puppetserver]',
-              'notify'  => 'Service[puppetserver]'
+              'require' => 'Class[Pupmod::Master::Install]',
+              'notify'  => 'Class[Pupmod::Master::Service]'
             }) }
 
             it { expect(webserver_conf_hash).to have_key('webserver') }
@@ -390,7 +390,7 @@ describe 'pupmod::master' do
                 'ensure'  => 'present',
                 'setting' => 'trusted_server_facts',
                 'value'   => true,
-                'notify'  => 'Service[puppetserver]'
+                'notify'  => 'Class[Pupmod::Master::Service]'
               })
             end
           end
@@ -399,21 +399,21 @@ describe 'pupmod::master' do
             'section' => 'master',
             'setting' => 'environmentpath',
             'value'   => '/etc/puppetlabs/code/environments',
-            'notify'  => 'Service[puppetserver]'
+            'notify'  => 'Class[Pupmod::Master::Service]'
           }) }
 
           it { is_expected.to contain_pupmod__conf('master_daemonize').with({
             'section' => 'master',
             'setting' => 'daemonize',
             'value'   => 'true',
-            'notify'  => 'Service[puppetserver]'
+            'notify'  => 'Class[Pupmod::Master::Service]'
           }) }
 
           it { is_expected.to contain_pupmod__conf('master_masterport').with({
             'section' => 'master',
             'setting' => 'masterport',
             'value'   => 8140,
-            'notify'  => 'Service[puppetserver]'
+            'notify'  => 'Class[Pupmod::Master::Service]'
           }) }
 
           if (Gem::Version.new(Puppet.version) >= Gem::Version.new('5.5.6'))
@@ -426,7 +426,7 @@ describe 'pupmod::master' do
                 'section' => 'master',
                 'setting' => 'ca',
                 'value'   => true,
-                'notify'  => 'Service[puppetserver]',
+                'notify'  => 'Class[Pupmod::Master::Service]',
               })
             end
           end
@@ -435,14 +435,14 @@ describe 'pupmod::master' do
             'section' => 'master',
             'setting' => 'ca_port',
             'value'   => 8141,
-            'notify'  => 'Service[puppetserver]'
+            'notify'  => 'Class[Pupmod::Master::Service]'
           }) }
 
           it { is_expected.to contain_pupmod__conf('ca_ttl').with({
             'section' => 'master',
             'setting' => 'ca_ttl',
             'value'   => '10y',
-            'notify'  => 'Service[puppetserver]'
+            'notify'  => 'Class[Pupmod::Master::Service]'
           }) }
 
           # fips_enabled fact take precedence over hieradata use_fips
@@ -450,13 +450,13 @@ describe 'pupmod::master' do
             'section' => 'master',
             'setting' => 'keylength',
             'value'   => 4096,
-            'notify'  => 'Service[puppetserver]'
+            'notify'  => 'Class[Pupmod::Master::Service]'
           }) }
 
           it { is_expected.to contain_pupmod__conf('freeze_main').with({
             'setting' => 'freeze_main',
             'value'   => false,
-            'notify'  => 'Service[puppetserver]'
+            'notify'  => 'Class[Pupmod::Master::Service]'
           }) }
           it { is_expected.to contain_ini_setting("pupmod_master_environmentpath") }
 
@@ -517,8 +517,8 @@ describe 'pupmod::master' do
                 'owner'   => 'root',
                 'group'   => 'puppet',
                 'mode'    => '0640',
-                'require' => 'Package[puppetserver]',
-                'notify'  => 'Service[puppetserver]'
+                'require' => 'Class[Pupmod::Master::Install]',
+                'notify'  => 'Class[Pupmod::Master::Service]'
               }) }
 
                 it { expect(ca_cfg_lines).to eq ([
@@ -534,8 +534,8 @@ describe 'pupmod::master' do
               'owner'   => 'root',
               'group'   => 'puppet',
               'mode'    => '0640',
-              'require' => 'Package[puppetserver]',
-              'notify'  => 'Service[puppetserver]',
+              'require' => 'Class[Pupmod::Master::Install]',
+              'notify'  => 'Class[Pupmod::Master::Service]',
               'content' => %q~<!--
   This file managed by Puppet.
   Any changes will be erased at the next run.
@@ -585,8 +585,8 @@ describe 'pupmod::master' do
                 'owner'   => 'root',
                 'group'   => 'puppet',
                 'mode'    => '0640',
-                'require' => 'Package[puppetserver]',
-                'notify'  => 'Service[puppetserver]'
+                'require' => 'Class[Pupmod::Master::Install]',
+                'notify'  => 'Class[Pupmod::Master::Service]'
               }) }
 
               it { expect(ca_conf_hash).to have_key('certificate-authority') }
@@ -609,8 +609,8 @@ describe 'pupmod::master' do
                 'owner'   => 'root',
                 'group'   => 'puppet',
                 'mode'    => '0640',
-                'require' => 'Package[puppetserver]',
-                'notify'  => 'Service[puppetserver]'
+                'require' => 'Class[Pupmod::Master::Install]',
+                'notify'  => 'Class[Pupmod::Master::Service]'
               }) }
 
               it { expect(ca_conf_hash).to have_key('certificate-authority') }
@@ -633,8 +633,8 @@ describe 'pupmod::master' do
                 'owner'   => 'root',
                 'group'   => 'puppet',
                 'mode'    => '0640',
-                'require' => 'Package[puppetserver]',
-                'notify'  => 'Service[puppetserver]'
+                'require' => 'Class[Pupmod::Master::Install]',
+                'notify'  => 'Class[Pupmod::Master::Service]'
               }) }
 
               it { expect(ca_conf_hash).to have_key('certificate-authority') }
@@ -659,8 +659,8 @@ describe 'pupmod::master' do
                 'owner'   => 'root',
                 'group'   => 'puppet',
                 'mode'    => '0640',
-                'require' => 'Package[puppetserver]',
-                'notify'  => 'Service[puppetserver]'
+                'require' => 'Class[Pupmod::Master::Install]',
+                'notify'  => 'Class[Pupmod::Master::Service]'
               }) }
 
               it { expect(os_settings_conf_hash).to have_key('os-settings') }

--- a/spec/classes/master_spec.rb
+++ b/spec/classes/master_spec.rb
@@ -483,7 +483,6 @@ describe 'pupmod::master' do
           context 'when server_distribution => PE' do
             let(:hieradata) { 'pe' }
 
-            it { is_expected.to contain_service('pe-puppetserver') }
             it { is_expected.not_to contain_service('puppetserver') }
           end
 


### PR DESCRIPTION
When installing puppetserver for the first time, the following resource ordering must be observed:
- `Service['puppetserver'] -> Exec['puppetserver_reload']`
- `Service['puppetserver'] ~> Exec['simp_generate_types']`
- `Puppet_authorization['/etc/puppetlabs/puppetserver/conf.d/auth.conf'] ~> Service['puppetserver']`