### PR TITLE
(SIMP-6922) concat pinned to wrong version in fixtures

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -19,9 +19,7 @@ fixtures:
       repo: https://github.com/simp/pupmod-puppetlabs-selinux_core
       puppet_version: ">= 6.0.0"
     compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup
-    concat:
-      repo: https://github.com/simp/puppetlabs-concat
-      ref: 5.3.0
+    concat: https://github.com/simp/puppetlabs-concat
     hocon:
       repo: https://github.com/puppetlabs/puppetlabs-hocon
       ref: 1.0.1

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -20,10 +20,8 @@ fixtures:
       puppet_version: ">= 6.0.0"
     compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup
     concat:
-      # master is beyond 4.1.1, but has breaking changes to
-      # how fragments are ordered (MODULES-6625)
       repo: https://github.com/simp/puppetlabs-concat
-      ref: 4.1.1
+      ref: 5.3.0
     hocon:
       repo: https://github.com/puppetlabs/puppetlabs-hocon
       ref: 1.0.1


### PR DESCRIPTION
- Tested with concat 5.3.0 to ensure compatibility with SIMP 6.4.0
- Updated fixtures to latest and greatest (6.x currently)