### PR TITLE
(SIMP-6919) Remove unnecessary EPEL repos in node sets

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -29,9 +29,7 @@ fixtures:
     simp_options: https://github.com/simp/pupmod-simp-simp_options
     simplib: https://github.com/simp/pupmod-simp-simplib
     stdlib: https://github.com/simp/puppetlabs-stdlib
-    systemd:
-      repo: https://github.com/simp/puppet-systemd
-      branch: simp-master
+    systemd: https://github.com/simp/puppet-systemd
     pam: https://github.com/simp/pupmod-simp-pam
     puppet_enterprise:
       repo: https://github.com/simp/pupmod-mock-puppet_enterprise

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -8,58 +8,13 @@
 HOSTS:
   puppet:
     roles:
-      - server # Mandatory
       - master
       - default
-      - simp_server
     platform:   el-7-x86_64
     box:        centos/7
     hypervisor: <%= hypervisor %>
     vagrant_memsize: 4608
     vagrant_cpus: 2
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
-        gpgkeys:
-          - https://getfedora.org/static/352C64E5.txt
-      simp:
-        baseurl: 'https://packagecloud.io/simp-project/6_X/el/$releasever/$basearch'
-        gpgkeys:
-          - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
-      simp_dependencies:
-        baseurl: 'https://packagecloud.io/simp-project/6_X_Dependencies/el/$releasever/$basearch'
-        gpgkeys:
-          - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6
-          - https://yum.puppet.com/RPM-GPG-KEY-puppetlabs
-          - https://yum.puppet.com/RPM-GPG-KEY-puppet
-          - https://apt.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-96
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
-
-  agent:
-    roles:
-      - agent
-    platform:   el-7-x86_64
-    box:        centos/7
-    hypervisor: <%= hypervisor %>
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
-        gpgkeys:
-          - https://getfedora.org/static/352C64E5.txt
-      simp:
-        baseurl: 'https://packagecloud.io/simp-project/6_X/el/$releasever/$basearch'
-        gpgkeys:
-          - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
-      simp_dependencies:
-        baseurl: 'https://packagecloud.io/simp-project/6_X_Dependencies/el/$releasever/$basearch'
-        gpgkeys:
-          - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6
-          - https://yum.puppet.com/RPM-GPG-KEY-puppetlabs
-          - https://yum.puppet.com/RPM-GPG-KEY-puppet
-          - https://apt.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-96
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
 CONFIG:
   log_level: verbose

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -8,56 +8,13 @@
 HOSTS:
   puppet:
     roles:
-      - server # Mandatory
       - master
       - default
-      - simp_server
     platform:   el-7-x86_64
     box:        onyxpoint/oel-7-x86_64
     hypervisor: <%= hypervisor %>
     vagrant_memsize: 4608
     vagrant_cpus: 2
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
-        gpgkeys:
-          - https://getfedora.org/static/352C64E5.txt
-      simp:
-        baseurl: 'https://packagecloud.io/simp-project/6_X/el/$releasever/$basearch'
-        gpgkeys:
-          - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
-      simp_dependencies:
-        baseurl: 'https://packagecloud.io/simp-project/6_X_Dependencies/el/$releasever/$basearch'
-        gpgkeys:
-          - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
-          - https://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs
-          - https://yum.puppetlabs.com/RPM-GPG-KEY-puppet
-          - https://apt.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-94
-          - https://getfedora.org/static/352C64E5.txt
-
-  agent:
-    roles:
-      - agent
-    platform:   el-7-x86_64
-    box:        onyxpoint/oel-7-x86_64
-    hypervisor: <%= hypervisor %>
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
-        gpgkeys:
-          - https://getfedora.org/static/352C64E5.txt
-      simp:
-        baseurl: 'https://packagecloud.io/simp-project/6_X/el/$releasever/$basearch'
-        gpgkeys:
-          - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
-      simp_dependencies:
-        baseurl: 'https://packagecloud.io/simp-project/6_X_Dependencies/el/$releasever/$basearch'
-        gpgkeys:
-          - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
-          - https://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs
-          - https://yum.puppetlabs.com/RPM-GPG-KEY-puppet
-          - https://apt.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-94
-          - https://getfedora.org/static/352C64E5.txt
 
 CONFIG:
   log_level: verbose

--- a/spec/acceptance/suites/default/01_puppet_server_spec.rb
+++ b/spec/acceptance/suites/default/01_puppet_server_spec.rb
@@ -35,8 +35,14 @@ describe 'install environment via r10k and puppetserver' do
     EOF
   }
 
+
+
   hosts_with_role(hosts, 'master').each do |master|
     context "on #{master}" do
+      it 'should enable SIMP and SIMP dependencies repos' do
+        install_simp_repos(master)
+      end
+
       it 'should install puppetserver' do
         master.install_package('puppetserver')
       end


### PR DESCRIPTION
- Remove EPEL from node sets
- Use install_simp_repos() in lieu of repos in node sets
- Remove unused agent node in node sets
- Use correct branch for puppet-systemd in fixtures

SIMP-6919 #comment pupmod-simp-pupmod
SIMP-6949 #comment pupmod-simp-pupmod