### PR TITLE
(SIMP-3913) Remove conflict with internal PE code

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Sep 02 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.11.1-0
+- Ensure that pupmod::pass_two does not conflict with the internal PE
+  configuration code for group ownership of puppet.conf
+
 * Fri Aug 02 2019 Robert Vincent <pillarsdotnet@gmail.com> - 7.11.1-0
 - Support puppetlabs/concat 6.x and puppetlabs/inifile 3.x.
 

--- a/manifests/pass_two.pp
+++ b/manifests/pass_two.pp
@@ -71,7 +71,7 @@ define pupmod::pass_two (
     }
   }
 
-  $_conf_group = 'puppet'
+  $_conf_group = $facts['puppet_settings']['master']['group']
 
   # These two maps allow the user and service specifications to occur purely in
   # data and can be included /only/ if the node is classified into the
@@ -137,10 +137,13 @@ define pupmod::pass_two (
     }
   }
 
+  # These items are managed on different files by both the FOSS and PE versions
   if ($_server_distribution == 'PC1') {
     $shared_mode = '0640'
+    $shared_group = $_conf_group
   } elsif ($_server_distribution == 'PE') {
     $shared_mode = undef
+    $shared_group = undef
   }
   file { $confdir:
     ensure => 'directory',
@@ -152,7 +155,7 @@ define pupmod::pass_two (
   file { "${confdir}/puppet.conf":
     ensure => 'file',
     owner  => 'root',
-    group  => $_conf_group,
+    group  => $shared_group,
     mode   => $shared_mode
   }
 

--- a/spec/defines/pass_two_spec.rb
+++ b/spec/defines/pass_two_spec.rb
@@ -78,8 +78,10 @@ describe 'pupmod::pass_two' do
               end
               unless $pe_mode
                 mode = '0640'
+                group = 'puppet'
               else
                 mode = nil
+                group = nil
               end
               it { is_expected.to contain_file('/etc/puppetlabs/puppet').with({
                 'ensure' => 'directory',
@@ -90,7 +92,7 @@ describe 'pupmod::pass_two' do
               it { is_expected.to contain_file('/etc/puppetlabs/puppet/puppet.conf').with({
                 'ensure' => 'file',
                 'owner'  => 'root',
-                'group'  => 'puppet',
+                'group'  => group,
                 'mode'   => mode
               }) }
               it { is_expected.to contain_group('puppet').with({


### PR DESCRIPTION
- Ensure that pupmod::pass_two does not conflict with the internal PE
  configuration code for group ownership of puppet.conf

SIMP-3913 #comment fix PE conflict on puppet.conf