### PR TITLE
(SIMP-7234) fix puppetserver.conf 'profiler-output-file' configruatio…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
+* Tue Nov 19 2019 Luke Stigdon <git@lukestigdon.com> - 7.11.1-0
+- Correct pupmod::master::profiler_output_file option name
+
 * Mon Sep 02 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.11.1-0
 - Ensure that pupmod::pass_two does not conflict with the internal PE
   configuration code for group ownership of puppet.conf
+- Support simp-simplib < 5
 
 * Fri Aug 02 2019 Robert Vincent <pillarsdotnet@gmail.com> - 7.11.1-0
 - Support puppetlabs/concat 6.x and puppetlabs/inifile 3.x.

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -143,7 +143,7 @@
 #
 #   * Only functional on ``puppetserver`` >= 5.4.1
 #
-# @param profiling_output_file
+# @param profiler_output_file
 #   The file to use when outputting server profiling information
 #
 #   * Only functional on ``puppetserver`` >= 5.4.1
@@ -299,7 +299,7 @@ class pupmod::master (
   Optional[Array[Pupmod::Master::SSLCipherSuites]]    $ssl_cipher_suites               = undef,
   Boolean                                             $enable_profiler                 = false,
   Pupmod::ProfilingMode                               $profiling_mode                  = 'off',
-  Stdlib::AbsolutePath                                $profiling_output_file           = "${vardir}/server_jruby_profiling",
+  Stdlib::AbsolutePath                                $profiler_output_file           = "${vardir}/server_jruby_profiling",
   Array[Simplib::Hostname]                            $admin_api_whitelist             = [$facts['fqdn']],
   String                                              $admin_api_mountpoint            = '/puppet-admin-api',
   Boolean                                             $log_to_file                     = false,

--- a/metadata.json
+++ b/metadata.json
@@ -51,7 +51,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.14.1 < 4.0.0"
+      "version_requirement": ">= 3.14.1 < 5.0.0"
     },
     {
       "name": "simp/pki",

--- a/spec/classes/master_spec.rb
+++ b/spec/classes/master_spec.rb
@@ -201,7 +201,7 @@ describe 'pupmod::master' do
                 puppetserver_tgt_hash['max-queued-requests']   = 10
                 puppetserver_tgt_hash['max-retry-delay']       = 1800
                 puppetserver_tgt_hash['profiling-mode']        = 'off'
-                puppetserver_tgt_hash['profiling-output-file'] = '/opt/puppetlabs/server/data/puppetserver/server_jruby_profiling'
+                puppetserver_tgt_hash['profiler-output-file'] = '/opt/puppetlabs/server/data/puppetserver/server_jruby_profiling'
               end
 
               if puppetserver_version >= '6.0.0'

--- a/templates/etc/puppetserver/conf.d/puppetserver.conf.epp
+++ b/templates/etc/puppetserver/conf.d/puppetserver.conf.epp
@@ -101,7 +101,7 @@ jruby-puppet: {
     # (optional) set the output file to direct JRuby profiler output. Should be
     # a fully qualified path writable by the service user. If not set will
     # default to a random name inside the service working directory.
-    profiling-output-file: <%= $pupmod::master::profiling_output_file %>
+    profiler-output-file: <%= $pupmod::master::profiler_output_file %>
 <% } -%>
 }
 


### PR DESCRIPTION
(SIMP-7234) fix puppetserver.conf 'profiler-output-file' configruation parameter

The output file for the JRuby profiler is configured by the
parameter 'profiler-output-file', not 'profiling-output-file'.

SIMP-7234 #close