### PR TITLE
(SIMP-7333) Remove legacy and deprecated features

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 * Mon Jan 06 2020 Michael Morrone <michael.morrone@onyxpoint.com> - 7.12.0-0
-- Remove deprecated CRL pull chron job
+- Remove deprecated CRL pull cron job
 - Remove support for legacy pki module
 
 * Tue Nov 19 2019 Luke Stigdon <git@lukestigdon.com> - 7.11.1-0

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Jan 06 2020 Michael Morrone <michael.morrone@onyxpoint.com> - 7.12.0-0
+- Remove deprecated CRL pull chron job
+- Remove support for legacy pki module
+
 * Tue Nov 19 2019 Luke Stigdon <git@lukestigdon.com> - 7.11.1-0
 - Correct pupmod::master::profiler_output_file option name
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 * Mon Jan 06 2020 Michael Morrone <michael.morrone@onyxpoint.com> - 7.12.0-0
-- Remove deprecated CRL pull cron job
-- Remove support for legacy pki module
+- Removed deprecated CA CRL pull cron job
+- Removed deprecated auth.conf support for legacy pki module
+- Removed deprecated simp_auth::server_distribution parameter
 
 * Tue Nov 19 2019 Luke Stigdon <git@lukestigdon.com> - 7.11.1-0
 - Correct pupmod::master::profiler_output_file option name

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Mon Jan 06 2020 Michael Morrone <michael.morrone@onyxpoint.com> - 7.12.0-0
+* Mon Jan 06 2020 Michael Morrone <michael.morrone@onyxpoint.com> - 8.0.0-0
 - Removed deprecated CA CRL pull cron job
 - Removed deprecated auth.conf support for legacy pki module
 - Removed deprecated simp_auth::server_distribution parameter

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,12 @@
 * Mon Jan 06 2020 Michael Morrone <michael.morrone@onyxpoint.com> - 8.0.0-0
-- Removed deprecated CA CRL pull cron job
-- Removed deprecated auth.conf support for legacy pki module
-- Removed deprecated simp_auth::server_distribution parameter
+- Removed the deprecated CA CRL pull cron job and the corresponding
+  pupmod::ca_crl_pull_interval parameter
+- Removed deprecated auth.conf support for the legacy pki module and
+  the corresponding parameters:
+  - pupmod::master::simp_auth::legacy_cacerts_all
+  - pupmod::master::simp_auth::legacy_mcollective_all
+  - pupmod::master::simp_auth::legacy_pki_keytabs_from_host
+- Removed the deprecated pupmod::master::simp_auth::server_distribution parameter
 
 * Tue Nov 19 2019 Luke Stigdon <git@lukestigdon.com> - 7.11.1-0
 - Correct pupmod::master::profiler_output_file option name

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,9 +21,6 @@
 #   The server distribution used. This changes the configuration based on whether
 #   we are using PC1 or PE
 #
-# @param ca_crl_pull_interval
-#   NOTE: This parameter is deprecated and throws a warning if specified.
-#
 # @param certname
 #   The puppet certificate CN name of the system.
 #
@@ -149,7 +146,6 @@ class pupmod (
   Simplib::Port                          $ca_port              = simplib::lookup('simp_options::puppet::ca_port', { 'default_value' => 8141 }),
   Simplib::Host                          $puppet_server        = simplib::lookup('simp_options::puppet::server', { 'default_value' => "puppet.${facts['domain']}" }),
   Simplib::ServerDistribution            $server_distribution  = pupmod::server_distribution(false), # Can't self-reference in this lookup
-  Optional                               $ca_crl_pull_interval = undef,
   Simplib::Host                          $certname             = $facts['fqdn'],
   String[0]                              $classfile            = '$vardir/classes.txt',
   Stdlib::AbsolutePath                   $confdir              = $::pupmod::params::puppet_config['confdir'],
@@ -185,10 +181,6 @@ class pupmod (
     # puppet configuration variable, like $vardir
 
     assert_type(Pattern['^(\$(?!/)|/).+'], $classfile)
-
-    if $ca_crl_pull_interval {
-      deprecation('pupmod::ca_crl_pull_interval', 'pupmod::ca_crl_pull_interval is deprecated, the CRL cron job has been removed.')
-    }
 
     if $haveged {
       include '::haveged'
@@ -243,7 +235,7 @@ class pupmod (
     # The workaround is to take advantage of the fact that the puppet
     # catalog compiler takes multiple passes, a first pass for most
     # classes to be evaluated, and a second pass for resource collection
-    # staetments. Basically by creating a virtual defined type and realizing
+    # statements. Basically by creating a virtual defined type and realizing
     # it immediately, we 'throw' any puppet code in the defined type into the
     # next pass of the compiler.
     #
@@ -359,9 +351,4 @@ class pupmod (
       }
     }
   }
-
-  # Make sure OBE cron job from pupmod versions prior to 7.3.1 is removed.
-  # This resource can be removed when the OBE ca_crl_pull_interval
-  # parameter is removed.
-  cron { 'puppet_crl_pull': ensure => 'absent' }
 }

--- a/manifests/pass_two.pp
+++ b/manifests/pass_two.pp
@@ -131,11 +131,6 @@ define pupmod::pass_two (
       include 'pupmod::master::sysconfig'
     }
   }
-  if (defined(Class['pupmod::master'])) {
-    class { 'pupmod::master::simp_auth':
-      server_distribution => $_server_distribution
-    }
-  }
 
   # These items are managed on different files by both the FOSS and PE versions
   if ($_server_distribution == 'PC1') {
@@ -145,6 +140,7 @@ define pupmod::pass_two (
     $shared_mode = undef
     $shared_group = undef
   }
+
   file { $confdir:
     ensure => 'directory',
     owner  => 'root',
@@ -195,5 +191,5 @@ define pupmod::pass_two (
         }
       }
     }
-    }
+  }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pupmod",
-  "version": "7.12.0",
+  "version": "8.0.0",
   "author": "SIMP Team",
   "summary": "A puppet module to manage puppetserver and puppet agents",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pupmod",
-  "version": "7.11.1",
+  "version": "7.12.0",
   "author": "SIMP Team",
   "summary": "A puppet module to manage puppetserver and puppet agents",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -162,8 +162,6 @@ describe 'pupmod' do
               end
             end
 
-            it { is_expected.to contain_cron('puppet_crl_pull').with_ensure('absent') }
-
             context 'with_selinux_disabled' do
               let(:facts) {
                 _facts = @extras.merge(os_facts)

--- a/spec/classes/master/simp_auth_spec.rb
+++ b/spec/classes/master/simp_auth_spec.rb
@@ -5,75 +5,41 @@ describe 'pupmod::master::simp_auth' do
     context "on #{os}" do
       let(:facts){ os_facts }
 
-      ['PE', 'PC1'].each do |server_distribution|
-        context "server distribution '#{server_distribution}'" do
-          let(:params) {{
-            :server_distribution => server_distribution
-          }}
-
-
-          it { is_expected.to create_class('pupmod::master::simp_auth') }
-          it { is_expected.to create_puppet_authorization__rule('Allow access to the PKI cacerts from the legacy pki module from all hosts').with({
-            'ensure'               => 'absent',
-            'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/pki/keydist/cacerts',
-            'match_request_type'   => 'regex',
-            'match_request_method' => ['get'],
-            'allow'                => '*',
-            'sort_order'           => 400,
-          }) }
-          it { is_expected.to create_puppet_authorization__rule('Allow access to the cacerts from the pki_files module from all hosts').with({
-            'ensure'               => 'present',
-            'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/pki_files/keydist/cacerts',
-            'match_request_type'   => 'regex',
-            'match_request_method' => ['get'],
-            'allow'                => '*',
-            'sort_order'           => 410,
-          }) }
-          it { is_expected.to create_puppet_authorization__rule('Allow access to the mcollective cacerts from the legacy pki module from all hosts').with({
-            'ensure'               => 'absent',
-            'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/pki/keydist/mcollective',
-            'match_request_type'   => 'regex',
-            'match_request_method' => ['get'],
-            'allow'                => '*',
-            'sort_order'           => 420,
-          }) }
-          it { is_expected.to create_puppet_authorization__rule('Allow access to the mcollective PKI from the pki_files module from all hosts').with({
-            'ensure'               => 'present',
-            'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/pki_files/keydist/mcollective',
-            'match_request_type'   => 'regex',
-            'match_request_method' => ['get'],
-            'allow'                => '*',
-            'sort_order'           => 430,
-          }) }
-          it { is_expected.to create_puppet_authorization__rule('Allow access to each hosts own certs from the pki_files module').with({
-            'ensure'               => 'present',
-            'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/pki_files/keydist/([^/]+)',
-            'match_request_type'   => 'regex',
-            'match_request_method' => ['get'],
-            'allow'                => '$2',
-            'sort_order'           => 440,
-          }) }
-          it { is_expected.to create_puppet_authorization__rule('Allow access to each hosts own kerberos keytabs from the legacy location').with({
-            'ensure'               => 'absent',
-            'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/pki_files/keytabs/([^/]+)',
-            'match_request_type'   => 'regex',
-            'match_request_method' => ['get'],
-            'allow'                => '$2',
-            'sort_order'           => 450,
-          }) }
-
-          it { is_expected.to create_puppet_authorization__rule('Allow access to each hosts own kerberos keytabs from the krb5_files module').with({
-            'ensure'               => 'present',
-            'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/krb5_files/keytabs/([^/]+)',
-            'match_request_type'   => 'regex',
-            'match_request_method' => ['get'],
-            'allow'                => '$2',
-            'sort_order'           => 460,
-            'notify'               => "Class[Pupmod::Master::Service]"
-          }) }
-          it { is_expected.to create_file('/etc/puppetlabs/puppet/auth.conf').with_ensure('absent') }
-        end
-      end
+      it { is_expected.to create_class('pupmod::master::simp_auth') }
+      it { is_expected.to create_puppet_authorization__rule('Allow access to the cacerts from the pki_files module from all hosts').with({
+        'ensure'               => 'present',
+        'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/pki_files/keydist/cacerts',
+        'match_request_type'   => 'regex',
+        'match_request_method' => ['get'],
+        'allow'                => '*',
+        'sort_order'           => 410,
+      }) }
+      it { is_expected.to create_puppet_authorization__rule('Allow access to the mcollective PKI from the pki_files module from all hosts').with({
+        'ensure'               => 'present',
+        'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/pki_files/keydist/mcollective',
+        'match_request_type'   => 'regex',
+        'match_request_method' => ['get'],
+        'allow'                => '*',
+        'sort_order'           => 430,
+      }) }
+      it { is_expected.to create_puppet_authorization__rule('Allow access to each hosts own certs from the pki_files module').with({
+        'ensure'               => 'present',
+        'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/pki_files/keydist/([^/]+)',
+        'match_request_type'   => 'regex',
+        'match_request_method' => ['get'],
+        'allow'                => '$2',
+        'sort_order'           => 440,
+      }) }
+      it { is_expected.to create_puppet_authorization__rule('Allow access to each hosts own kerberos keytabs from the krb5_files module').with({
+        'ensure'               => 'present',
+        'match_request_path'   => '^/puppet/v3/file_(metadata|content)/modules/krb5_files/keytabs/([^/]+)',
+        'match_request_type'   => 'regex',
+        'match_request_method' => ['get'],
+        'allow'                => '$2',
+        'sort_order'           => 460,
+        'notify'               => "Class[Pupmod::Master::Service]"
+      }) }
+      it { is_expected.to create_file('/etc/puppetlabs/puppet/auth.conf').with_ensure('absent') }
     end
   end
 end


### PR DESCRIPTION
* Removed Puppet CRL pull cron, which was previously deprecated
* Removed keydist rules that utilized the legacy pki module

SIMP-7333 #close
SIMP-7424 #close