### PR TITLE
(SIMP-7573) Fix simp_generate_types systemd path

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -13,7 +13,7 @@ fixtures:
       puppet_version: ">= 6.0.0"
     firewalld:
       repo: https://github.com/simp/pupmod-voxpupuli-firewalld
-      ref: v4.1.0
+      ref: v4.2.2
     haveged: https://github.com/simp/pupmod-simp-haveged
     inifile: https://github.com/simp/puppetlabs-inifile
     iptables: https://github.com/simp/pupmod-simp-iptables

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -187,7 +187,7 @@ pup5.5.16-oel-fips:
 pup6:
   <<: *pup_6
   <<: *acceptance_base
-  # Waiting on resolution to https://tickets.puppetlabs.com/browse/PUP-10262
+  # Waiting on resolution to https://tickets.puppetlabs.com/browse/PUP-9602
   allow_failure: true
   script:
     - 'bundle exec rake beaker:suites[default,default]'
@@ -195,7 +195,7 @@ pup6:
 pup6-fips:
   <<: *pup_6
   <<: *acceptance_base
-  # Waiting on resolution to https://tickets.puppetlabs.com/browse/PUP-10262
+  # Waiting on resolution to https://tickets.puppetlabs.com/browse/PUP-9602
   allow_failure: true
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,default]'

--- a/spec/classes/master/generate_types_spec.rb
+++ b/spec/classes/master/generate_types_spec.rb
@@ -54,6 +54,9 @@ describe 'pupmod::master::generate_types' do
 
       context 'with default input' do
         systemd_path_content = <<~EOM
+          [Install]
+          WantedBy=multi-user.target
+
           [Path]
           Unit=simp_generate_types.service
           PathChanged=/etc/puppetlabs/code/environments
@@ -61,6 +64,9 @@ describe 'pupmod::master::generate_types' do
         EOM
 
         systemd_app_content = <<~EOM
+          [Install]
+          WantedBy=multi-user.target
+
           [Path]
           Unit=simp_generate_types_force.service
           PathChanged=/opt/puppetlabs/server/apps/puppetserver/bin/puppetserver
@@ -81,6 +87,9 @@ describe 'pupmod::master::generate_types' do
         }}
 
         systemd_path_content = <<~EOM
+          [Install]
+          WantedBy=multi-user.target
+
           [Path]
           Unit=simp_generate_types.service
           PathChanged=/etc/puppetlabs/code/environments
@@ -88,6 +97,9 @@ describe 'pupmod::master::generate_types' do
         EOM
 
         systemd_app_content = <<~EOM
+          [Install]
+          WantedBy=multi-user.target
+
           [Path]
           Unit=simp_generate_types_force.service
           PathChanged=/opt/puppetlabs/puppet/bin/puppet
@@ -107,6 +119,9 @@ describe 'pupmod::master::generate_types' do
         }}
 
         systemd_path_content = <<~EOM
+          [Install]
+          WantedBy=multi-user.target
+
           [Path]
           Unit=simp_generate_types.service
           PathChanged=/etc/puppetlabs/code/environments
@@ -114,6 +129,9 @@ describe 'pupmod::master::generate_types' do
         EOM
 
         systemd_app_content = <<~EOM
+          [Install]
+          WantedBy=multi-user.target
+
           [Path]
           Unit=simp_generate_types_force.service
           PathChanged=/opt/puppetlabs/server/apps/puppetserver/bin/puppetserver
@@ -134,6 +152,9 @@ describe 'pupmod::master::generate_types' do
         }}
 
         systemd_path_content = <<~EOM
+          [Install]
+          WantedBy=multi-user.target
+
           [Path]
           Unit=simp_generate_types.service
           PathChanged=/etc/puppetlabs/code/environments
@@ -154,12 +175,18 @@ describe 'pupmod::master::generate_types' do
         }}
 
         systemd_path_content = <<~EOM
+          [Install]
+          WantedBy=multi-user.target
+
           [Path]
           Unit=simp_generate_types.service
           PathExistsGlob=/etc/puppetlabs/code/environments/*/modules/*/lib/puppet/type/*.rb
         EOM
 
         systemd_app_content = <<~EOM
+          [Install]
+          WantedBy=multi-user.target
+
           [Path]
           Unit=simp_generate_types_force.service
           PathChanged=/opt/puppetlabs/server/apps/puppetserver/bin/puppetserver
@@ -180,12 +207,18 @@ describe 'pupmod::master::generate_types' do
         }}
 
         systemd_path_content = <<~EOM
+          [Install]
+          WantedBy=multi-user.target
+
           [Path]
           Unit=simp_generate_types.service
           PathChanged=/etc/puppetlabs/code/environments
         EOM
 
         systemd_app_content = <<~EOM
+          [Install]
+          WantedBy=multi-user.target
+
           [Path]
           Unit=simp_generate_types_force.service
           PathChanged=/opt/puppetlabs/server/apps/puppetserver/bin/puppetserver
@@ -208,6 +241,9 @@ describe 'pupmod::master::generate_types' do
         }
 
         systemd_path_content = <<~EOM
+          [Install]
+          WantedBy=multi-user.target
+
           [Path]
           Unit=simp_generate_types.service
           PathChanged=/etc/puppetlabs/code/environments
@@ -216,6 +252,9 @@ describe 'pupmod::master::generate_types' do
         EOM
 
         systemd_app_content = <<~EOM
+          [Install]
+          WantedBy=multi-user.target
+
           [Path]
           Unit=simp_generate_types_force.service
           PathChanged=/opt/puppetlabs/server/apps/puppetserver/bin/puppetserver

--- a/templates/etc/systemd/system/simp_generate_types.path.epp
+++ b/templates/etc/systemd/system/simp_generate_types.path.epp
@@ -1,4 +1,7 @@
 <%- | Boolean $apps = false | -%>
+[Install]
+WantedBy=multi-user.target
+
 [Path]
 <% if $apps { -%>
 Unit=simp_generate_types_force.service


### PR DESCRIPTION
Ensure that the simp_generate_types systemd path is enabled at boot
time.

SIMP-7573 #close