### PR TITLE
(SIMP-7830) Resolve systemd error on EL6

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -13,7 +13,7 @@ fixtures:
       puppet_version: ">= 6.0.0"
     firewalld:
       repo: https://github.com/simp/pupmod-voxpupuli-firewalld
-      ref: v4.2.2
+      ref: v4.3.0
     haveged: https://github.com/simp/pupmod-simp-haveged
     inifile: https://github.com/simp/puppetlabs-inifile
     iptables: https://github.com/simp/pupmod-simp-iptables

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue Jun 23 2020 Adam Yohrling <adam.yohrling@onyxpoint.com> - 8.0.0-0
+- Resolved bug with systemd when simp_generate_types disabled
+
 * Tue May 26 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 8.0.0-0
 - Add EL8 Support
 - Removed incron support in favor of using systemd path units to run

--- a/manifests/master/generate_types.pp
+++ b/manifests/master/generate_types.pp
@@ -144,10 +144,15 @@ class pupmod::master::generate_types (
   else {
     service { 'simp_generate_types': enable => false }
     service { 'simp_generate_types_force': enable => false }
-    systemd::unit_file { 'simp_generate_types.path': ensure => absent }
-    systemd::unit_file { 'simp_generate_types_apps.path': ensure =>  absent }
-    systemd::unit_file { 'simp_generate_types.service': ensure => absent }
-    systemd::unit_file { 'simp_generate_types_force.service': ensure => absent }
+
+    if 'systemd' in pick(fact('init_systems'), []) {
+      simplib::assert_optional_dependency($module_name, 'camptocamp/systemd')
+
+      systemd::unit_file { 'simp_generate_types.path': ensure => absent }
+      systemd::unit_file { 'simp_generate_types_apps.path': ensure =>  absent }
+      systemd::unit_file { 'simp_generate_types.service': ensure => absent }
+      systemd::unit_file { 'simp_generate_types_force.service': ensure => absent }
+    }
   }
 
   # TODO: Remove this when enough time has passed that it is no longer necessary

--- a/spec/classes/master/generate_types_spec.rb
+++ b/spec/classes/master/generate_types_spec.rb
@@ -280,10 +280,17 @@ describe 'pupmod::master::generate_types' do
         it { is_expected.to_not create_exec('simp_generate_types') }
         it { is_expected.to create_service('simp_generate_types').with_enable(false) }
         it { is_expected.to create_service('simp_generate_types_force').with_enable(false) }
-        it { is_expected.to create_systemd__unit_file('simp_generate_types.path').with_ensure('absent') }
-        it { is_expected.to create_systemd__unit_file('simp_generate_types_apps.path').with_ensure('absent') }
-        it { is_expected.to create_systemd__unit_file('simp_generate_types.service').with_ensure('absent') }
-        it { is_expected.to create_systemd__unit_file('simp_generate_types_force.service').with_ensure('absent') }
+        if Array(os_facts[:init_systems]).include?('systemd')
+          it { is_expected.to create_systemd__unit_file('simp_generate_types.path').with_ensure('absent') }
+          it { is_expected.to create_systemd__unit_file('simp_generate_types_apps.path').with_ensure('absent') }
+          it { is_expected.to create_systemd__unit_file('simp_generate_types.service').with_ensure('absent') }
+          it { is_expected.to create_systemd__unit_file('simp_generate_types_force.service').with_ensure('absent') }
+        else
+          it { is_expected.to_not create_systemd__unit_file('simp_generate_types.path').with_ensure('absent') }
+          it { is_expected.to_not create_systemd__unit_file('simp_generate_types_apps.path').with_ensure('absent') }
+          it { is_expected.to_not create_systemd__unit_file('simp_generate_types.service').with_ensure('absent') }
+          it { is_expected.to_not create_systemd__unit_file('simp_generate_types_force.service').with_ensure('absent') }
+        end
         it { is_expected.to create_tidy('/etc/incron.d').with_matches('simp_generate_types*') }
       end
     end


### PR DESCRIPTION
This change adds a check for systemd when generate_types is disabled,
resolving an error with handling unit-files that was breaking compile
in EL6 nodes.

Also updates spec tests and fixtures for acceptance issues.

SIMP-7830 #close