### PR TITLE
(SIMP-8623) Bootstrap failing after 6.19 update

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -222,6 +222,13 @@ variables:
     BEAKER_PUPPET_COLLECTION: 'puppet6'
     MATRIX_RUBY_VERSION: '2.5'
 
+.pup_6_19_0: &pup_6_19_0
+  image: 'ruby:2.5'
+  variables:
+    PUPPET_VERSION: '6.19.0'
+    BEAKER_PUPPET_COLLECTION: 'puppet6'
+    MATRIX_RUBY_VERSION: '2.5'
+
 # Testing Environments
 #-----------------------------------------------------------------------
 
@@ -305,6 +312,10 @@ pup6.18.0-unit:
   <<: *pup_6_18_0
   <<: *unit_tests
 
+pup6.19.0-unit:
+  <<: *pup_6_19_0
+  <<: *unit_tests
+
 # ------------------------------------------------------------------------------
 #             NOTICE: **This file is maintained with puppetsync**
 #
@@ -380,3 +391,16 @@ pup6.18.0-oel-fips:
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel]'
+
+pup6.19.0:
+  <<: *pup_6_19_0
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites[default,default]'
+
+pup6.19.0-fips:
+  <<: *pup_6_19_0
+  <<: *acceptance_base
+  script:
+    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,default]'
+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -312,10 +312,6 @@ pup6.18.0-unit:
   <<: *pup_6_18_0
   <<: *unit_tests
 
-pup6.19.0-unit:
-  <<: *pup_6_19_0
-  <<: *unit_tests
-
 # ------------------------------------------------------------------------------
 #             NOTICE: **This file is maintained with puppetsync**
 #
@@ -391,16 +387,4 @@ pup6.18.0-oel-fips:
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel]'
-
-pup6.19.0:
-  <<: *pup_6_19_0
-  <<: *acceptance_base
-  script:
-    - 'bundle exec rake beaker:suites[default,default]'
-
-pup6.19.0-fips:
-  <<: *pup_6_19_0
-  <<: *acceptance_base
-  script:
-    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,default]'
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -222,13 +222,6 @@ variables:
     BEAKER_PUPPET_COLLECTION: 'puppet6'
     MATRIX_RUBY_VERSION: '2.5'
 
-.pup_6_19_0: &pup_6_19_0
-  image: 'ruby:2.5'
-  variables:
-    PUPPET_VERSION: '6.19.0'
-    BEAKER_PUPPET_COLLECTION: 'puppet6'
-    MATRIX_RUBY_VERSION: '2.5'
-
 # Testing Environments
 #-----------------------------------------------------------------------
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Fri Oct 23 2020 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 8.1.1-0
+- Puppet 6.19 has changed the "master" section to "server" in Puppet.settings.
+  This fix updates the modules to check puppet_settings[:server] first then
+  puppet_settings[:master].
+
 * Tue Sep 22 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 8.1.0-0
 - Set the default puppetserver ciphers to a safe set
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1002,6 +1002,14 @@ and/or domain facts.
 
 Default value: ``true``
 
+##### `cve_2020_7942_warning`
+
+Data type: `Boolean`
+
+Whether to warn about CVE-2020-7942 when the issue is detected.
+
+Default value: ``true``
+
 ##### `syslog`
 
 Data type: `Boolean`
@@ -1150,14 +1158,6 @@ Data type: `Boolean`
 DO NOT USE. needed for rspec testing
 
 Default value: ``false``
-
-##### `cve_2020_7942_warning`
-
-Data type: `Boolean`
-
-
-
-Default value: ``true``
 
 ### `pupmod::master::base`
 
@@ -1629,7 +1629,7 @@ Data type: `String`
 
 The ``user`` that the ``puppetserver`` service will run as.
 
-Default value: `$facts['puppet_settings']['master']['user']`
+Default value: `pick($facts.dig('puppet_settings','server','user'),$facts.dig('puppet_settings','master','user'))`
 
 ##### `group`
 
@@ -1637,7 +1637,7 @@ Data type: `String`
 
 The ``group`` that the ``puppetserver`` service will run as.
 
-Default value: `$facts['puppet_settings']['master']['group']`
+Default value: `pick($facts.dig('puppet_settings','server','group'),$facts.dig('puppet_settings','master','group'))`
 
 ##### `mock`
 

--- a/functions/server_distribution.pp
+++ b/functions/server_distribution.pp
@@ -10,8 +10,15 @@ function pupmod::server_distribution (
   Boolean $lookup_from_pupmod = true
 ){
 
-  # Figure out what we think we have
-  if fact('pe_build') or (fact('puppet_settings.master.user') == 'pe-puppet') {
+
+  # In Puppet 6.19 the section "master" was renamed to "server" in Puppet.settings.
+  # pick is used here to determine correct value for backwards compatability
+  $_puppet_user = pick(
+    $facts.dig('puppet_settings','server','user'),
+    $facts.dig('puppet_settings','master','user')
+  )
+
+  if fact('pe_build') or ( $_puppet_user == 'pe-puppet') {
     $server_type = 'PE'
   }
   else {

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -173,6 +173,9 @@
 #
 #   * Do NOT set to `false` unless you have read the details of CVE-2020-7942
 #
+# @param cve_2020_7942_warning
+#   Whether to warn about CVE-2020-7942 when the issue is detected.
+#
 # @param syslog
 #   If true, log to the local system logger over UDP port 514.
 #

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -333,8 +333,10 @@ class pupmod::master (
 ) inherits pupmod {
 
   $_server_version = pupmod::server_version()
-  $_puppet_user = $facts['puppet_settings']['master']['user']
-  $_puppet_group = $facts['puppet_settings']['master']['group']
+  # In Puppet 6.19 the section "master" was renamed to "server" in Puppet.settings.
+  # pick is used here to determine correct value for backwards compatability
+  $_puppet_user = pick($facts.dig('puppet_settings','server','user'),$facts.dig('puppet_settings','master','user'))
+  $_puppet_group = pick($facts.dig('puppet_settings','server','group'),$facts.dig('puppet_settings','master','group'))
 
   if ($mock == false) {
     include 'pupmod::master::install'

--- a/manifests/master/autosign.pp
+++ b/manifests/master/autosign.pp
@@ -14,10 +14,14 @@ define pupmod::master::autosign (
 ) {
   include 'pupmod::master'
 
+  # In Puppet 6.19 the section "master was renamed to "server" in Puppet.settings.
+  # pick is used here to determine correct value for backwards compatability
+  $_puppet_group = pick($facts.dig('puppet_settings','server','group'),$facts.dig('puppet_settings','master','group'))
+
   ensure_resource('concat', "${pupmod::confdir}/autosign.conf", {
     'ensure' => 'present',
     'owner'  => 'root',
-    'group'  => $facts['puppet_settings']['master']['group'],
+    'group'  => $_puppet_group,
     'mode'   => '0640',
     'notify' => Class['pupmod::master::service']
   })

--- a/manifests/master/base.pp
+++ b/manifests/master/base.pp
@@ -7,6 +7,10 @@ class pupmod::master::base {
 
   Class['pupmod::master::install'] ~> Class['pupmod::master::service']
 
+  # In Puppet 6.19 the section "master was renamed to "server" in Puppet.settings.
+  # pick is used here to determine correct value for backwards compatability
+  $_puppet_group = pick($facts.dig('puppet_settings','server','group'),$facts.dig('puppet_settings','master','group'))
+
   exec { 'puppetserver_reload':
     command     => '/usr/local/sbin/puppetserver_reload',
     refreshonly => true,
@@ -17,7 +21,7 @@ class pupmod::master::base {
   file { $pupmod::master::environmentpath:
     ensure       => 'directory',
     owner        => 'root',
-    group        => $facts['puppet_settings']['master']['group'],
+    group        => $_puppet_group,
     mode         => 'u=rwx,g=rwx,o-rwx',
     recurse      => true,
     recurselimit => 1

--- a/manifests/master/fileserver_entry.pp
+++ b/manifests/master/fileserver_entry.pp
@@ -15,10 +15,14 @@ define pupmod::master::fileserver_entry (
 ) {
   include 'pupmod::master'
 
+  # In Puppet 6.19 the section "master was renamed to "server" in Puppet.settings.
+  # pick is used here to determine correct value for backwards compatability
+  $_puppet_group = pick($facts.dig('puppet_settings','server','group'),$facts.dig('puppet_settings','master','group'))
+
   ensure_resource('concat', "${pupmod::confdir}/fileserver.conf", {
     'ensure' => 'present',
     'owner'  => 'root',
-    'group'  => $facts['puppet_settings']['master']['group'],
+    'group'  => $_puppet_group,
     'mode'   => '0640',
     'notify' => Class['pupmod::master::service']
   })

--- a/manifests/master/sysconfig.pp
+++ b/manifests/master/sysconfig.pp
@@ -75,8 +75,8 @@ class pupmod::master::sysconfig (
   Integer                        $service_stop_retries = 60,
   Integer                        $start_timeout        = 120,
   Simplib::ServerDistribution    $server_distribution  = pupmod::server_distribution(),
-  String                         $user                 = $facts['puppet_settings']['master']['user'],
-  String                         $group                = $facts['puppet_settings']['master']['group'],
+  String                         $user                 = pick($facts.dig('puppet_settings','server','user'),$facts.dig('puppet_settings','master','user')),
+  String                         $group                = pick($facts.dig('puppet_settings','server','group'),$facts.dig('puppet_settings','master','group')),
   Boolean                        $mock                 = false
 ) inherits pupmod {
 

--- a/manifests/master/sysconfig.pp
+++ b/manifests/master/sysconfig.pp
@@ -95,9 +95,15 @@ class pupmod::master::sysconfig (
       default => $java_max_memory,
     }
 
+
+    # In Puppet 6.19 the section "master was renamed to "server" in Puppet.settings.
+    # pick is used here to determine correct value for backwards compatability
+    $_server_datadir = pick($facts.dig('puppet_settings','server','server_datadir'),$facts.dig('puppet_settings','master','server_datadir'))
+
     if empty($java_temp_dir) {
       # puppet_settings.master.server_datadir is not always present, but its parent is
-      $_java_temp_dir = "${dirname(fact('puppet_settings.master.server_datadir'))}/pserver_tmp"
+      $_p_server_datadir = dirname($_server_datadir)
+      $_java_temp_dir = "${_p_server_datadir}/pserver_tmp"
     }
     else {
       $_java_temp_dir = $java_temp_dir

--- a/manifests/pass_two.pp
+++ b/manifests/pass_two.pp
@@ -71,7 +71,9 @@ define pupmod::pass_two (
     }
   }
 
-  $_conf_group = $facts['puppet_settings']['master']['group']
+  # In Puppet 6.19 the section "master was renamed to "server" in Puppet.settings.
+  # pick is used here to determine correct value for backwards compatability
+  $_conf_group = pick($facts.dig('puppet_settings','server','group'),$facts.dig('puppet_settings','master','group'))
 
   # These two maps allow the user and service specifications to occur purely in
   # data and can be included /only/ if the node is classified into the

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pupmod",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "author": "SIMP Team",
   "summary": "A puppet module to manage puppetserver and puppet agents",
   "license": "Apache-2.0",

--- a/spec/classes/10_classes/master/base_spec.rb
+++ b/spec/classes/10_classes/master/base_spec.rb
@@ -6,7 +6,11 @@ describe 'pupmod::master::base' do
       @extras = { :puppet_settings => {
         'master' => {
           'rest_authconfig' => '/etc/puppetlabs/puppet/authconf.conf'
-      }}}
+        },
+        'server' => {
+          'rest_authconfig' => '/etc/puppetlabs/puppet/authconf.conf'
+        }
+      }}
     end
     context "on #{os}" do
 

--- a/spec/classes/10_classes/master/sysconfig_spec.rb
+++ b/spec/classes/10_classes/master/sysconfig_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'hocon'
 
 describe 'pupmod::master' do
   on_supported_os.each do |os, os_facts|

--- a/spec/classes/10_classes/master/sysconfig_spec.rb
+++ b/spec/classes/10_classes/master/sysconfig_spec.rb
@@ -4,6 +4,9 @@ describe 'pupmod::master' do
   on_supported_os.each do |os, os_facts|
     before :all do
       @extras = { :puppet_settings => {
+        'server' => {
+          'rest_authconfig' => '/etc/puppetlabs/puppet/authconf.conf'
+        },
         'master' => {
           'rest_authconfig' => '/etc/puppetlabs/puppet/authconf.conf'
       }}}
@@ -11,6 +14,9 @@ describe 'pupmod::master' do
 
     puppetserver_content_without_jruby = File.read("#{File.dirname(__FILE__)}/data/puppetserver.txt")
     context "on #{os}" do
+
+      _server_datadir = os_facts.dig(:puppet_settings,:server,:server_datadir) ||
+         os_facts.dig(:puppet_settings,:master,:server_datadir)
 
       ['PE', 'PC1'].each do |server_distribution|
         context "server distribution '#{server_distribution}'" do
@@ -27,7 +33,7 @@ describe 'pupmod::master' do
           if server_distribution == 'PE'
             context 'on PE with default params' do
               let(:hieradata) { 'sysconfig/PE' }
-            
+
               let(:facts){
                 @extras.merge(os_facts).merge(
                   :memorysize_mb => '490.16',
@@ -56,10 +62,11 @@ describe 'pupmod::master' do
                   }
                  })
               }
+
               it do
                 puppetserver_content = File.read("#{File.dirname(__FILE__)}/data/puppetserver-j9.txt")
                 puppetserver_content.gsub!('%PUPPETSERVER_JAVA_TMPDIR_ROOT%',
-                  File.dirname(facts[:puppet_settings][:master][:server_datadir]))
+                  File.dirname(_server_datadir))
 
                 is_expected.to contain_file('/etc/sysconfig/puppetserver').with( {
                   'owner'   => 'root',
@@ -70,7 +77,7 @@ describe 'pupmod::master' do
               end
 
               it { is_expected.to create_class('pupmod::master::sysconfig') }
-              it { is_expected.to contain_file("#{File.dirname(facts[:puppet_settings][:master][:server_datadir])}/pserver_tmp").with(
+              it { is_expected.to contain_file("#{File.dirname(_server_datadir)}/pserver_tmp").with(
                 {
                   'owner'  => 'puppet',
                   'group'  => 'puppet',
@@ -91,7 +98,7 @@ describe 'pupmod::master' do
               }
               it do
                 puppetserver_content_without_jruby.gsub!('%PUPPETSERVER_JAVA_TMPDIR_ROOT%',
-                  File.dirname(facts[:puppet_settings][:master][:server_datadir]))
+                  File.dirname(_server_datadir))
 
                 is_expected.to contain_file('/etc/sysconfig/puppetserver').with( {
                   'owner'   => 'root',
@@ -108,7 +115,7 @@ describe 'pupmod::master' do
 
               it do
                 puppetserver_content_without_jruby.gsub!('%PUPPETSERVER_JAVA_TMPDIR_ROOT%',
-                  File.dirname(facts[:puppet_settings][:master][:server_datadir]))
+                  File.dirname(_server_datadir))
 
                 is_expected.to contain_file('/etc/sysconfig/puppetserver').with( {
                   'owner'   => 'root',
@@ -124,7 +131,7 @@ describe 'pupmod::master' do
 
               it do
                 puppetserver_content_without_jruby.gsub!('%PUPPETSERVER_JAVA_TMPDIR_ROOT%',
-                  File.dirname(facts[:puppet_settings][:master][:server_datadir]))
+                  File.dirname(_server_datadir))
 
                 is_expected.to contain_file('/etc/sysconfig/puppetserver').with( {
                   'owner'   => 'root',
@@ -166,7 +173,7 @@ describe 'pupmod::master' do
                     else
                       mi = 2
                     end
-  
+
                     mi
                   }
                   let(:params) {{
@@ -178,7 +185,7 @@ describe 'pupmod::master' do
                   it do
                     puppetserver_content = File.read("#{File.dirname(__FILE__)}/data/puppetserver-j9-rcc-#{server_type}-48.txt")
                     puppetserver_content.gsub!('%PUPPETSERVER_JAVA_TMPDIR_ROOT%',
-                      File.dirname(facts[:puppet_settings][:master][:server_datadir]))
+                      File.dirname(_server_datadir))
 
                     is_expected.to contain_file('/etc/sysconfig/puppetserver').with( {
                       'owner'   => 'root',
@@ -189,7 +196,7 @@ describe 'pupmod::master' do
                   end
 
                   it { is_expected.to create_class('pupmod::master::sysconfig') }
-                  it { is_expected.to contain_file("#{File.dirname(facts[:puppet_settings][:master][:server_datadir])}/pserver_tmp").with(
+                  it { is_expected.to contain_file("#{File.dirname(_server_datadir)}/pserver_tmp").with(
                     {
                       'owner'  => 'puppet',
                       'group'  => 'puppet',
@@ -234,7 +241,7 @@ describe 'pupmod::master' do
                     else
                       mi = 4
                     end
-  
+
                     mi
                   }
                   let(:params) {{
@@ -246,7 +253,7 @@ describe 'pupmod::master' do
                   it do
                     puppetserver_content = File.read("#{File.dirname(__FILE__)}/data/puppetserver-j9-rcc-#{server_type}-1632.txt")
                     puppetserver_content.gsub!('%PUPPETSERVER_JAVA_TMPDIR_ROOT%',
-                      File.dirname(facts[:puppet_settings][:master][:server_datadir]))
+                      File.dirname(_server_datadir))
 
                     is_expected.to contain_file('/etc/sysconfig/puppetserver').with( {
                       'owner'   => 'root',
@@ -257,7 +264,7 @@ describe 'pupmod::master' do
                   end
 
                   it { is_expected.to create_class('pupmod::master::sysconfig') }
-                  it { is_expected.to contain_file("#{File.dirname(facts[:puppet_settings][:master][:server_datadir])}/pserver_tmp").with(
+                  it { is_expected.to contain_file("#{File.dirname(_server_datadir)}/pserver_tmp").with(
                     {
                       'owner'  => 'puppet',
                       'group'  => 'puppet',
@@ -299,7 +306,7 @@ describe 'pupmod::master' do
               it do
                 puppetserver_content = File.read("#{File.dirname(__FILE__)}/data/puppetserver-j9-tuning_overrides.txt")
                 puppetserver_content.gsub!('%PUPPETSERVER_JAVA_TMPDIR_ROOT%',
-                  File.dirname(facts[:puppet_settings][:master][:server_datadir]))
+                  File.dirname(_server_datadir))
 
                 is_expected.to contain_file('/etc/sysconfig/puppetserver').with( {
                   'owner'   => 'root',
@@ -310,7 +317,7 @@ describe 'pupmod::master' do
               end
 
               it { is_expected.to create_class('pupmod::master::sysconfig') }
-              it { is_expected.to contain_file("#{File.dirname(facts[:puppet_settings][:master][:server_datadir])}/pserver_tmp").with(
+              it { is_expected.to contain_file("#{File.dirname(_server_datadir)}/pserver_tmp").with(
                 {
                   'owner'  => 'puppet',
                   'group'  => 'puppet',


### PR DESCRIPTION
 - Puppet 6.19 renamed the master section to server in puppet.settings.
      The code was updated to check the server section first and if that
      was undefined check the master section.
    
    SIMP-8623 #close
