### PR TITLE
(SIMP-8592) Default to certname

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Nov 05 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 8.1.2-0
+- Default to TLS1.2 only
+- Use `certname` by default and fall back to `fqdn` for bolt, etc..
+
 * Fri Oct 23 2020 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 8.1.1-0
 - Puppet 6.19 has changed the "master" section to "server" in Puppet.settings.
   This fix updates the modules to check puppet_settings[:server] first then

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -103,7 +103,7 @@ The puppet certificate CN name of the system.
 See http://docs.puppetlabs.com/references/latest/configuration.html for
 additional details.
 
-Default value: `$facts['fqdn']`
+Default value: `pick($facts['certname'], $facts['fqdn'])`
 
 ##### `classfile`
 
@@ -849,7 +849,7 @@ Data type: `Array[Simplib::Host]`
 An array of certificate short names which will be allowed to query the CA end
 point of the Puppet Server
 
-Default value: `[$facts['fqdn']]`
+Default value: `[pick($facts['certname'], $facts['fqdn'])]`
 
 ##### `ruby_load_path`
 
@@ -916,11 +916,10 @@ Default value: `'off'`
 
 Data type: `Array[Pupmod::Master::SSLProtocols]`
 
-Default: ['TLSv1','TLSv1.1','TLSv1.2']
 The protocols that are allowed for communication with the Puppet Server. See
 the ssl-protocols documentation for the Puppet Server for additional details.
 
-Default value: `['TLSv1', 'TLSv1.1', 'TLSv1.2']`
+Default value: `['TLSv1.2']`
 
 ##### `ssl_cipher_suites`
 
@@ -970,7 +969,7 @@ Data type: `Array[Simplib::Hostname]`
 A list of X.509 certificate names that should be allowed to access the Puppet
 Server's administrative API.
 
-Default value: `[$facts['fqdn']]`
+Default value: `[pick($facts['certname'], $facts['fqdn'])]`
 
 ##### `admin_api_mountpoint`
 

--- a/SIMP/compliance_profiles/checks.yaml
+++ b/SIMP/compliance_profiles/checks.yaml
@@ -243,8 +243,6 @@ checks:
     settings:
       parameter: pupmod::master::ssl_protocols
       value:
-      - TLSv1
-      - TLSv1.1
       - TLSv1.2
     type: puppet-class-parameter
     controls:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -162,7 +162,7 @@ class pupmod (
   Simplib::Port                          $ca_port              = simplib::lookup('simp_options::puppet::ca_port', { 'default_value' => 8141 }),
   Simplib::Host                          $puppet_server        = simplib::lookup('simp_options::puppet::server', { 'default_value' => "puppet.${facts['domain']}" }),
   Simplib::ServerDistribution            $server_distribution  = pupmod::server_distribution(false), # Can't self-reference in this lookup
-  Simplib::Host                          $certname             = $facts['fqdn'],
+  Simplib::Host                          $certname             = pick($facts['certname'], $facts['fqdn']),
   String[0]                              $classfile            = '$vardir/classes.txt',
   Stdlib::AbsolutePath                   $confdir              = $::pupmod::params::puppet_config['confdir'],
   Boolean                                $daemonize            = false,

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -129,7 +129,6 @@
 #   Set the JRuby ``CompileMode``.
 #
 # @param ssl_protocols
-#   Default: ['TLSv1','TLSv1.1','TLSv1.2']
 #   The protocols that are allowed for communication with the Puppet Server. See
 #   the ssl-protocols documentation for the Puppet Server for additional details.
 #
@@ -305,7 +304,7 @@ class pupmod::master (
   Integer[0]                                          $max_queued_requests             = 10,
   Integer[1]                                          $max_retry_delay                 = 1800,
   Boolean                                             $firewall                        = simplib::lookup('simp_options::firewall', { 'default_value' => false }),
-  Array[Simplib::Host]                                $ca_status_whitelist             = [$facts['fqdn']],
+  Array[Simplib::Host]                                $ca_status_whitelist             = [pick($facts['certname'], $facts['fqdn'])],
   Optional[Stdlib::AbsolutePath]                      $ruby_load_path                  = undef,
   Integer[1]                                          $max_active_instances            = pupmod::max_active_instances($server_type),
   Integer                                             $max_requests_per_instance       = 100000,
@@ -313,12 +312,12 @@ class pupmod::master (
   Boolean                                             $environment_class_cache_enabled = true,
   Optional[Pattern['^\d+\.\d+$']]                     $compat_version                  = undef,
   Enum['off', 'jit', 'force']                         $compile_mode                    = 'off',
-  Array[Pupmod::Master::SSLProtocols]                 $ssl_protocols                   = ['TLSv1', 'TLSv1.1', 'TLSv1.2'],
+  Array[Pupmod::Master::SSLProtocols]                 $ssl_protocols                   = ['TLSv1.2'],
   Optional[Array[Pupmod::Master::SSLCipherSuites]]    $ssl_cipher_suites               = undef,
   Boolean                                             $enable_profiler                 = false,
   Pupmod::ProfilingMode                               $profiling_mode                  = 'off',
   Stdlib::AbsolutePath                                $profiler_output_file            = "${vardir}/server_jruby_profiling",
-  Array[Simplib::Hostname]                            $admin_api_whitelist             = [$facts['fqdn']],
+  Array[Simplib::Hostname]                            $admin_api_whitelist             = [pick($facts['certname'], $facts['fqdn'])],
   String                                              $admin_api_mountpoint            = '/puppet-admin-api',
   Boolean                                             $log_to_file                     = false,
   Boolean                                             $strict_hostname_checking        = true,

--- a/manifests/master/generate_types.pp
+++ b/manifests/master/generate_types.pp
@@ -135,8 +135,10 @@ class pupmod::master::generate_types (
       }
     }
     else {
+      $_target = pick($facts['certname'], $facts['fqdn'])
+
       notify { 'simp_generate_types incron deprecated':
-        message  => "simp_generate_types no longer supports incron due to continuing issues with the application. Please set ${module_name}::master::generate_types::enable to `false` for ${facts['fqdn']} to disable this message",
+        message  => "simp_generate_types no longer supports incron due to continuing issues with the application. Please set ${module_name}::master::generate_types::enable to `false` for ${_target} to disable this message",
         loglevel => 'warning'
       }
     }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pupmod",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "author": "SIMP Team",
   "summary": "A puppet module to manage puppetserver and puppet agents",
   "license": "Apache-2.0",

--- a/spec/classes/20_classes/master_spec.rb
+++ b/spec/classes/20_classes/master_spec.rb
@@ -221,7 +221,7 @@ describe 'pupmod::master' do
             it {
               expect(puppetserver_conf_hash['http-client']).to match(
                 a_hash_including(
-                  'ssl-protocols' => [ 'TLSv1', 'TLSv1.1', 'TLSv1.2' ]
+                  'ssl-protocols' => [ 'TLSv1.2' ]
                 )
               )
             }
@@ -304,7 +304,7 @@ describe 'pupmod::master' do
                     'ssl-key'           => "/etc/puppetlabs/puppet/ssl/private_keys/#{facts[:fqdn]}.pem",
                     'ssl-host'          => '0.0.0.0',
                     'ssl-port'          => 8140,
-                    'ssl-protocols'     => 'TLSv1,TLSv1.1,TLSv1.2',
+                    'ssl-protocols'     => 'TLSv1.2',
                     'default-server'    => true
                   }
                 ),
@@ -318,7 +318,7 @@ describe 'pupmod::master' do
                     'ssl-key'           => "/etc/puppetlabs/puppet/ssl/private_keys/#{facts[:fqdn]}.pem",
                     'ssl-host'          => '0.0.0.0',
                     'ssl-port'          => 8141,
-                    'ssl-protocols'     => 'TLSv1,TLSv1.1,TLSv1.2',
+                    'ssl-protocols'     => 'TLSv1.2',
                   }
                 )
               )


### PR DESCRIPTION
Fixed:
  - Default to TLS1.2 only
  - Use `certname` by default and fall back to `fqdn` for bolt, etc..

SIMP-8592 #close
SIMP-8655 #comment Default pupmod to TLS1.2