### PR TITLE
(SIMP-8592) certname is a trusted fact

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Dec 02 2020 Chris Tessmer <chris.tessmer@onyxpoint.com> - 8.1.3-0
+- Get `certname` from trusted facts ONLY for authenticated remote requests
+
 * Thu Nov 05 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 8.1.2-0
 - Default to TLS1.2 only
 - Use `certname` by default and fall back to `fqdn` for bolt, etc..

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -100,10 +100,15 @@ Data type: `Simplib::Host`
 
 The puppet certificate CN name of the system.
 
-See http://docs.puppetlabs.com/references/latest/configuration.html for
-additional details.
+* For authenticated remote requests, this defaults to `$trusted['certname']
+* For all other requests (e.g., bolt), the default is `$facts['clientcert']`
 
-Default value: `pick($facts['certname'], $facts['fqdn'])`
+For additional details, see:
+
+* http://docs.puppetlabs.com/references/latest/configuration.html
+* https://puppet.com/docs/puppet/latest/lang_facts_builtin_variables.html
+
+Default value: `(`
 
 ##### `classfile`
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pupmod",
-  "version": "8.1.2",
+  "version": "8.1.3",
   "author": "SIMP Team",
   "summary": "A puppet module to manage puppetserver and puppet agents",
   "license": "Apache-2.0",

--- a/spec/classes/20_classes/init_spec.rb
+++ b/spec/classes/20_classes/init_spec.rb
@@ -4,6 +4,7 @@ audit_content = File.open("#{File.dirname(__FILE__)}/data/auditd.txt", "rb").rea
 
 describe 'pupmod' do
   on_supported_os.each do |os, os_facts|
+    let(:node){ os_facts[:fqdn] } # sets trusted facts hash
     before :all do
       @extras = { :puppet_settings => {
         'master' => {


### PR DESCRIPTION
This patch:

  * Fixes a bug ([`certname` comes from $trusted, not $facts][0])
  * Adds logic to use `certname` ONLY for authenticated remote
    requests
  * Uses `facts['clientcert']`, then `$facts['fqdn']` as a fallback

[0]: https://puppet.com/docs/puppet/6.17/lang_facts_builtin_variables.html

[SIMP-8592] #close #comment {{certname}} is a trusted fact

[SIMP-8592]: https://simp-project.atlassian.net/browse/SIMP-8592