### PR TITLE
(SIMP-9608) Default pupmod::set_environment to false

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
-* Wed Apr 28 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 8.1.3
-- Fixed a bug where the pupmod::master::sysconfig class was not getting applied
+* Wed May 26 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 8.1.3
+- Fixed
+  - Fixed a bug where the pupmod::master::sysconfig class was not getting applied
+
+- Changed
+  - Default pupmod::set_environment to `false` so that users don't accidentally
+    end up with systems in the wrong environment
 
 * Tue Jan 12 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 8.1.3
 - Removed EL6 support

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -415,7 +415,7 @@ Set the environment on the system to the currently running environment
   various puppet tools. To prevent this from happening, you may set this to
   `no_clean` and the entry will be preserved if present.
 
-Default value: ``true``
+Default value: ``false``
 
 ### <a name="pupmodagentcron"></a>`pupmod::agent::cron`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -195,7 +195,7 @@ class pupmod (
   Boolean                                $firewall             = simplib::lookup('simp_options::firewall', { 'default_value' => false }),
   Hash                                   $pe_classlist         = {},
   String[1]                              $package_ensure       = simplib::lookup('simp_options::package_ensure' , { 'default_value' => 'installed'}),
-  Variant[Boolean, Enum['no_clean']]     $set_environment      = true,
+  Variant[Boolean, Enum['no_clean']]     $set_environment      = false,
   Boolean                                $manage_facter_conf   = false,
   Stdlib::Absolutepath                   $facter_conf_dir      = '/etc/puppetlabs/facter',
   Hash                                   $facter_options,      # module data

--- a/spec/classes/20_classes/init_spec.rb
+++ b/spec/classes/20_classes/init_spec.rb
@@ -42,19 +42,9 @@ describe 'pupmod' do
               'setting' => 'splay',
               'value' => false
             }) }
+
             it { is_expected.not_to contain_pupmod__conf('splaylimit') }
-
-            it { is_expected.to contain_pupmod__conf('environment').with({
-              'section' => 'agent',
-              'setting' => 'environment',
-              'value' => 'rp_env'
-            }) }
-
-            it { is_expected.to contain_pupmod__conf('remove environment from main').with({
-              'ensure' => 'absent',
-              'section' => 'main',
-              'setting' => 'environment'
-            }) }
+            it { is_expected.not_to contain_pupmod__conf('environment') }
 
             it { is_expected.to contain_pupmod__conf('syslogfacility').with({
               'setting' => 'syslogfacility',
@@ -168,11 +158,6 @@ describe 'pupmod' do
 
               it { is_expected.not_to contain_selboolean('puppetagent_manage_all_files') }
             end
-
-            context 'running from bolt' do
-              let(:environment) { 'bolt_catalog'}
-              it { is_expected.not_to contain_pupmod__conf('environment') }
-            end
           end
 
           describe "with non-default parameters" do
@@ -208,9 +193,25 @@ describe 'pupmod' do
               it { is_expected.to contain_ini_setting("pupmod_splaylimit") }
             end
 
-            context 'with set_environment disabled' do
-              let(:params) {{ :set_environment => false }}
-              it { is_expected.not_to contain_pupmod__conf('environment') }
+            context 'with set_environment enabled ' do
+              let(:params) {{ :set_environment => true }}
+
+              it { is_expected.to contain_pupmod__conf('environment').with({
+                'section' => 'agent',
+                'setting' => 'environment',
+                'value' => 'rp_env'
+              }) }
+
+              it { is_expected.to contain_pupmod__conf('remove environment from main').with({
+                'ensure' => 'absent',
+                'section' => 'main',
+                'setting' => 'environment'
+              }) }
+
+              context 'running from bolt' do
+                let(:environment) { 'bolt_catalog'}
+                it { is_expected.not_to contain_pupmod__conf('environment') }
+              end
             end
 
             context 'with manage_facter_conf => true' do

--- a/spec/unit/compliance_engine/compliance_engine_enforce_spec.rb
+++ b/spec/unit/compliance_engine/compliance_engine_enforce_spec.rb
@@ -133,11 +133,6 @@ describe 'compliance_markup', type: :class do
             expect(compliance_profile_data).to_not be_nil
           end
 
-          it "should have a #{info[:percent_compliant]}% compliant report" do
-            expect(compliance_profile_data['summary']['percent_compliant'])
-              .to eq(info[:percent_compliant])
-          end
-
           # The list of report sections that should not exist and if they do
           # exist, we need to know what is wrong so that we can fix them
           report_validators = [
@@ -179,6 +174,11 @@ describe 'compliance_markup', type: :class do
                 expect(normalized[report_section]).to be_empty
               end
             end
+          end
+
+          it "should have at least #{info[:percent_compliant]}% report compliance" do
+            expect(compliance_profile_data['summary']['percent_compliant'])
+              .to be >= info[:percent_compliant]
           end
         end
       end


### PR DESCRIPTION
- Changed
  - Default pupmod::set_environment to `false` so that users don't accidentally
    end up with systems in the wrong environment

SIMP-9608 #close