### PR TITLE
(SIMP-MAINT) pupmod Remove invalid blanks line within CHANGELOG entries

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,7 +7,6 @@
   - Converted all `cron` items to `systemd` timers
   - Converted the cleanup jobs to `tmpfiles` jobs
   - Converted from the 'params' patter to module data
-
 - Added
   - Purge puppet logs > 30 days by default
   - Disable puppetserver analytics by default
@@ -15,7 +14,6 @@
 * Wed May 26 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 8.1.3
 - Fixed
   - Fixed a bug where the pupmod::master::sysconfig class was not getting applied
-
 - Changed
   - Default pupmod::set_environment to `false` so that users don't accidentally
     end up with systems in the wrong environment


### PR DESCRIPTION
Remove blank lines that causes information to be missed when
the tag changelog is generated.