### PR TITLE
(SIMP-10399) Change all `master` configs to `server`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,9 @@
-* Wed Aug 04 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 8.2.0
+* Tue Aug 17 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 8.2.0
+- Change all instances of pupmod::master adding items to the `master` section to
+  use `server` instead
+- Update pupmod::conf to automatically switch `master` to `server`
+- Automatically remove items from the puppet config in the `master` section that
+  are set in the `server` section
 - Added pupmod::master::sysconfig::use_code_cache_flushing to reduce excessive
   memory usage
 - Removed SHA1 ciphers from the server cipher list

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 - Added pupmod::master::sysconfig::use_code_cache_flushing to reduce excessive
   memory usage
 - Removed SHA1 ciphers from the server cipher list
+- Disable the internal Red Hat FIPS option in the puppet server
 
 * Wed Jul 28 2021 Andy Adrian <andy.adrian@onyxpoint.com> - 8.2.0
 - Updated pupmod::puppet_server to accept Array as well as single hosts

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -431,7 +431,7 @@ class pupmod::master (
     }
 
     pupmod::conf { 'master_environmentpath':
-      section => 'master',
+      section => 'server',
       confdir => $puppet_confdir,
       setting => 'environmentpath',
       value   => $environmentpath,
@@ -439,7 +439,7 @@ class pupmod::master (
     }
 
     pupmod::conf { 'master_daemonize':
-      section => 'master',
+      section => 'server',
       confdir => $puppet_confdir,
       setting => 'daemonize',
       value   => $daemonize,
@@ -447,7 +447,7 @@ class pupmod::master (
     }
 
     pupmod::conf { 'master_masterport':
-      section => 'master',
+      section => 'server',
       confdir => $puppet_confdir,
       setting => 'masterport',
       value   => $masterport,
@@ -480,12 +480,12 @@ class pupmod::master (
       setting => 'ca',
       value   => $enable_ca,
       confdir => $puppet_confdir,
-      section => 'master',
+      section => 'server',
       notify  => Class['pupmod::master::service']
     }
 
     pupmod::conf { 'master_ca_port':
-      section => 'master',
+      section => 'server',
       confdir => $puppet_confdir,
       setting => 'ca_port',
       value   => $ca_port,
@@ -493,7 +493,7 @@ class pupmod::master (
     }
 
     pupmod::conf { 'ca_ttl':
-      section => 'master',
+      section => 'server',
       confdir => $puppet_confdir,
       setting => 'ca_ttl',
       value   => $ca_ttl,
@@ -508,7 +508,7 @@ class pupmod::master (
     }
 
     pupmod::conf { 'keylength':
-      section => 'master',
+      section => 'server',
       confdir => $puppet_confdir,
       setting => 'keylength',
       value   => $_keylength,

--- a/spec/acceptance/suites/default/01_puppet_server_spec.rb
+++ b/spec/acceptance/suites/default/01_puppet_server_spec.rb
@@ -51,7 +51,16 @@ describe 'install environment via r10k and puppetserver' do
       end
 
       it 'should install puppetserver' do
-        master.install_package('puppetserver')
+        if ( on(master, 'cat /proc/sys/crypto/fips_enabled', :accept_all_exit_codes => true).stdout.strip == '1' )
+        # Change to the following when it works for all RHEL-like OSs
+        # if master.fips_mode?
+          master.install_package('yum-utils')
+          master.install_package('java-headless')
+          on(master, 'yumdownloader puppetserver')
+          on(master, 'rpm -i --force --nodigest --nofiledigest puppetserver*.rpm')
+        else
+          master.install_package('puppetserver')
+        end
       end
 
       it 'should enable autosigning' do

--- a/spec/classes/10_classes/master/data/puppetserver-j9-rcc-compile-1632.txt
+++ b/spec/classes/10_classes/master/data/puppetserver-j9-rcc-compile-1632.txt
@@ -2,8 +2,8 @@
 JAVA_BIN="/usr/bin/java"
 
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
-JAVA_ARGS="-Xms15360m -Xmx15360m -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:ReservedCodeCacheSize=2048m -XX:+UseCodeCacheFlushing"
-JAVA_ARGS_CLI="-Xms15360m -Xmx15360m -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:ReservedCodeCacheSize=2048m -XX:+UseCodeCacheFlushing"
+JAVA_ARGS="-Xms15360m -Xmx15360m -Dcom.redhat.fips=false -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:ReservedCodeCacheSize=2048m -XX:+UseCodeCacheFlushing"
+JAVA_ARGS_CLI="-Xms15360m -Xmx15360m -Dcom.redhat.fips=false -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:ReservedCodeCacheSize=2048m -XX:+UseCodeCacheFlushing"
 
 JRUBY_JAR="/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar"
 

--- a/spec/classes/10_classes/master/data/puppetserver-j9-rcc-compile-48.txt
+++ b/spec/classes/10_classes/master/data/puppetserver-j9-rcc-compile-48.txt
@@ -2,8 +2,8 @@
 JAVA_BIN="/usr/bin/java"
 
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
-JAVA_ARGS="-Xms1536m -Xmx1536m -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:ReservedCodeCacheSize=512m -XX:+UseCodeCacheFlushing"
-JAVA_ARGS_CLI="-Xms1536m -Xmx1536m -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:ReservedCodeCacheSize=512m -XX:+UseCodeCacheFlushing"
+JAVA_ARGS="-Xms1536m -Xmx1536m -Dcom.redhat.fips=false -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:ReservedCodeCacheSize=512m -XX:+UseCodeCacheFlushing"
+JAVA_ARGS_CLI="-Xms1536m -Xmx1536m -Dcom.redhat.fips=false -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:ReservedCodeCacheSize=512m -XX:+UseCodeCacheFlushing"
 
 JRUBY_JAR="/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar"
 

--- a/spec/classes/10_classes/master/data/puppetserver-j9-rcc-monolithic-1632.txt
+++ b/spec/classes/10_classes/master/data/puppetserver-j9-rcc-monolithic-1632.txt
@@ -2,8 +2,8 @@
 JAVA_BIN="/usr/bin/java"
 
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
-JAVA_ARGS="-Xms11264m -Xmx11264m -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:ReservedCodeCacheSize=2048m -XX:+UseCodeCacheFlushing"
-JAVA_ARGS_CLI="-Xms11264m -Xmx11264m -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:ReservedCodeCacheSize=2048m -XX:+UseCodeCacheFlushing"
+JAVA_ARGS="-Xms11264m -Xmx11264m -Dcom.redhat.fips=false -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:ReservedCodeCacheSize=2048m -XX:+UseCodeCacheFlushing"
+JAVA_ARGS_CLI="-Xms11264m -Xmx11264m -Dcom.redhat.fips=false -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:ReservedCodeCacheSize=2048m -XX:+UseCodeCacheFlushing"
 
 JRUBY_JAR="/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar"
 

--- a/spec/classes/10_classes/master/data/puppetserver-j9-rcc-monolithic-48.txt
+++ b/spec/classes/10_classes/master/data/puppetserver-j9-rcc-monolithic-48.txt
@@ -2,8 +2,8 @@
 JAVA_BIN="/usr/bin/java"
 
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
-JAVA_ARGS="-Xms1024m -Xmx1024m -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:ReservedCodeCacheSize=512m -XX:+UseCodeCacheFlushing"
-JAVA_ARGS_CLI="-Xms1024m -Xmx1024m -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:ReservedCodeCacheSize=512m -XX:+UseCodeCacheFlushing"
+JAVA_ARGS="-Xms1024m -Xmx1024m -Dcom.redhat.fips=false -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:ReservedCodeCacheSize=512m -XX:+UseCodeCacheFlushing"
+JAVA_ARGS_CLI="-Xms1024m -Xmx1024m -Dcom.redhat.fips=false -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:ReservedCodeCacheSize=512m -XX:+UseCodeCacheFlushing"
 
 JRUBY_JAR="/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar"
 

--- a/spec/classes/10_classes/master/data/puppetserver-j9-rcc-primary-1632.txt
+++ b/spec/classes/10_classes/master/data/puppetserver-j9-rcc-primary-1632.txt
@@ -2,8 +2,8 @@
 JAVA_BIN="/usr/bin/java"
 
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
-JAVA_ARGS="-Xms4096m -Xmx4096m -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:ReservedCodeCacheSize=2048m -XX:+UseCodeCacheFlushing"
-JAVA_ARGS_CLI="-Xms4096m -Xmx4096m -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:ReservedCodeCacheSize=2048m -XX:+UseCodeCacheFlushing"
+JAVA_ARGS="-Xms4096m -Xmx4096m -Dcom.redhat.fips=false -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:ReservedCodeCacheSize=2048m -XX:+UseCodeCacheFlushing"
+JAVA_ARGS_CLI="-Xms4096m -Xmx4096m -Dcom.redhat.fips=false -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:ReservedCodeCacheSize=2048m -XX:+UseCodeCacheFlushing"
 
 JRUBY_JAR="/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar"
 

--- a/spec/classes/10_classes/master/data/puppetserver-j9-rcc-primary-48.txt
+++ b/spec/classes/10_classes/master/data/puppetserver-j9-rcc-primary-48.txt
@@ -2,8 +2,8 @@
 JAVA_BIN="/usr/bin/java"
 
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
-JAVA_ARGS="-Xms1024m -Xmx1024m -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:ReservedCodeCacheSize=512m -XX:+UseCodeCacheFlushing"
-JAVA_ARGS_CLI="-Xms1024m -Xmx1024m -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:ReservedCodeCacheSize=512m -XX:+UseCodeCacheFlushing"
+JAVA_ARGS="-Xms1024m -Xmx1024m -Dcom.redhat.fips=false -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:ReservedCodeCacheSize=512m -XX:+UseCodeCacheFlushing"
+JAVA_ARGS_CLI="-Xms1024m -Xmx1024m -Dcom.redhat.fips=false -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:ReservedCodeCacheSize=512m -XX:+UseCodeCacheFlushing"
 
 JRUBY_JAR="/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar"
 

--- a/spec/classes/10_classes/master/data/puppetserver-j9-tuning_overrides.txt
+++ b/spec/classes/10_classes/master/data/puppetserver-j9-tuning_overrides.txt
@@ -2,8 +2,8 @@
 JAVA_BIN="/usr/bin/java"
 
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
-JAVA_ARGS="-Xms10240m -Xmx20480m -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:ReservedCodeCacheSize=10240m -XX:+UseCodeCacheFlushing"
-JAVA_ARGS_CLI="-Xms10240m -Xmx20480m -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:ReservedCodeCacheSize=10240m -XX:+UseCodeCacheFlushing"
+JAVA_ARGS="-Xms10240m -Xmx20480m -Dcom.redhat.fips=false -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:ReservedCodeCacheSize=10240m -XX:+UseCodeCacheFlushing"
+JAVA_ARGS_CLI="-Xms10240m -Xmx20480m -Dcom.redhat.fips=false -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:ReservedCodeCacheSize=10240m -XX:+UseCodeCacheFlushing"
 
 JRUBY_JAR="/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar"
 

--- a/spec/classes/10_classes/master/data/puppetserver-j9.txt
+++ b/spec/classes/10_classes/master/data/puppetserver-j9.txt
@@ -2,8 +2,8 @@
 JAVA_BIN="/usr/bin/java"
 
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
-JAVA_ARGS="-Xms245m -Xmx245m -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:+UseCodeCacheFlushing"
-JAVA_ARGS_CLI="-Xms245m -Xmx245m -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:+UseCodeCacheFlushing"
+JAVA_ARGS="-Xms245m -Xmx245m -Dcom.redhat.fips=false -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:+UseCodeCacheFlushing"
+JAVA_ARGS_CLI="-Xms245m -Xmx245m -Dcom.redhat.fips=false -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:+UseCodeCacheFlushing"
 
 JRUBY_JAR="/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar"
 

--- a/spec/classes/10_classes/master/data/puppetserver.txt
+++ b/spec/classes/10_classes/master/data/puppetserver.txt
@@ -2,8 +2,8 @@
 JAVA_BIN="/usr/bin/java"
 
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
-JAVA_ARGS="-Xms245m -Xmx245m -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:+UseCodeCacheFlushing"
-JAVA_ARGS_CLI="-Xms245m -Xmx245m -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:+UseCodeCacheFlushing"
+JAVA_ARGS="-Xms245m -Xmx245m -Dcom.redhat.fips=false -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:+UseCodeCacheFlushing"
+JAVA_ARGS_CLI="-Xms245m -Xmx245m -Dcom.redhat.fips=false -Djava.io.tmpdir=%PUPPETSERVER_JAVA_TMPDIR_ROOT%/pserver_tmp -XX:+UseCodeCacheFlushing"
 
 # These normally shouldn't need to be edited if using OS packages
 USER="puppet"

--- a/spec/classes/20_classes/master_spec.rb
+++ b/spec/classes/20_classes/master_spec.rb
@@ -414,21 +414,21 @@ describe 'pupmod::master' do
           end
 
           it { is_expected.to contain_pupmod__conf('master_environmentpath').with({
-            'section' => 'master',
+            'section' => 'server',
             'setting' => 'environmentpath',
             'value'   => '/etc/puppetlabs/code/environments',
             'notify'  => 'Class[Pupmod::Master::Service]'
           }) }
 
           it { is_expected.to contain_pupmod__conf('master_daemonize').with({
-            'section' => 'master',
+            'section' => 'server',
             'setting' => 'daemonize',
             'value'   => 'true',
             'notify'  => 'Class[Pupmod::Master::Service]'
           }) }
 
           it { is_expected.to contain_pupmod__conf('master_masterport').with({
-            'section' => 'master',
+            'section' => 'server',
             'setting' => 'masterport',
             'value'   => 8140,
             'notify'  => 'Class[Pupmod::Master::Service]'
@@ -441,7 +441,7 @@ describe 'pupmod::master' do
           else
             it 'ensures that "[master] ca = true" is absent when Puppet < 5.5.6' do
               is_expected.to contain_pupmod__conf('master_ca').with({
-                'section' => 'master',
+                'section' => 'server',
                 'setting' => 'ca',
                 'value'   => true,
                 'notify'  => 'Class[Pupmod::Master::Service]',
@@ -450,14 +450,14 @@ describe 'pupmod::master' do
           end
 
           it { is_expected.to contain_pupmod__conf('master_ca_port').with({
-            'section' => 'master',
+            'section' => 'server',
             'setting' => 'ca_port',
             'value'   => 8141,
             'notify'  => 'Class[Pupmod::Master::Service]'
           }) }
 
           it { is_expected.to contain_pupmod__conf('ca_ttl').with({
-            'section' => 'master',
+            'section' => 'server',
             'setting' => 'ca_ttl',
             'value'   => '10y',
             'notify'  => 'Class[Pupmod::Master::Service]'
@@ -465,7 +465,7 @@ describe 'pupmod::master' do
 
           # fips_enabled fact take precedence over hieradata use_fips
           it { is_expected.to contain_pupmod__conf('keylength').with({
-            'section' => 'master',
+            'section' => 'server',
             'setting' => 'keylength',
             'value'   => 4096,
             'notify'  => 'Class[Pupmod::Master::Service]'

--- a/spec/defines/conf_spec.rb
+++ b/spec/defines/conf_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+describe 'pupmod::conf' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) do
+        os_facts
+      end
+
+      let(:title) do
+        'test_thing'
+      end
+
+      context 'with basic settings' do
+        let(:params) do
+          {
+            :setting => 'test',
+            :value   => 20,
+            :confdir => '/whatever'
+          }
+        end
+
+        it do
+          is_expected.to contain_ini_setting("pupmod_#{title}")
+            .with_setting(params[:setting])
+            .with_value(params[:value])
+            .with_path("#{params[:confdir]}/puppet.conf")
+            .with_section('main')
+        end
+      end
+
+      context 'with a setting of "environment"' do
+        let(:params) do
+          {
+            :setting => 'environment',
+            :value   => 'foobar',
+            :confdir => '/whatever'
+          }
+        end
+
+        it do
+          is_expected.to contain_ini_setting("pupmod_#{title}")
+            .with_setting(params[:setting])
+            .with_value(params[:value])
+            .with_path("#{params[:confdir]}/puppet.conf")
+            .with_section('agent')
+        end
+      end
+
+      context 'with a section of "master"' do
+        let(:params) do
+          {
+            :setting => 'foo',
+            :section => 'master',
+            :value   => 'foobar',
+            :confdir => '/whatever'
+          }
+        end
+
+        it do
+          is_expected.to contain_ini_setting("pupmod_#{title}")
+            .with_setting(params[:setting])
+            .with_value(params[:value])
+            .with_path("#{params[:confdir]}/puppet.conf")
+            .with_section('server')
+        end
+
+        it do
+          is_expected.to contain_ini_setting("pupmod_#{title}_clean")
+            .with_ensure('absent')
+            .with_setting(params[:setting])
+            .with_path("#{params[:confdir]}/puppet.conf")
+            .with_section('master')
+        end
+      end
+    end
+  end
+end

--- a/templates/etc/sysconfig/puppetserver.epp
+++ b/templates/etc/sysconfig/puppetserver.epp
@@ -26,6 +26,8 @@
     [
       "-Xms${java_start_memory}",
       "-Xmx${java_max_memory}",
+      # TODO - Remove this when native FIPS hooks work properly
+      '-Dcom.redhat.fips=false',
       "-Djava.io.tmpdir=${pupmod::master::sysconfig::_java_temp_dir}"
     ] +
       $reserved_code_cache +


### PR DESCRIPTION
* Fixed
  - Change all instances of pupmod::master adding items to the `master` section to
    use `server` instead
  - Update pupmod::conf to automatically switch `master` to `server`
  - Automatically remove items from the puppet config in the `master` section that
    are set in the `server` section

SIMP-10399 #close