### PR TITLE
Update deps to use puppet/systemd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,12 @@
 .idea/
 dist
 /pkg
-/spec/fixtures
+# Read everything in fixtures
+/spec/fixtures/*
+# Un-ignore hieradata
+!/spec/fixtures/hieradata/*
+# Except this one, which is auto-generated
+/spec/fixtures/hieradata/hiera.yaml
 /spec/rp_env
 /.rspec_system
 /.vagrant

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Jun 03 2022 Chris Tessmer <chris.tessmer@onyxpoint.com> - 8.3.0
+- Update from camptocamp/systemd to puppet/systemd
+
 * Tue Aug 17 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 8.2.0
 - Change all instances of pupmod::master adding items to the `master` section to
   use `server` instead

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pupmod",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "author": "SIMP Team",
   "summary": "A puppet module to manage puppetserver and puppet agents",
   "license": "Apache-2.0",
@@ -18,8 +18,8 @@
   ],
   "dependencies": [
     {
-      "name": "camptocamp/systemd",
-      "version_requirement": ">= 2.7.0 < 3.0.0"
+      "name": "puppet/systemd",
+      "version_requirement": ">= 3.0.0 < 4.0.0"
     },
     {
       "name": "simp/haveged",


### PR DESCRIPTION
This patch updates from camptocamp/systemd 2.x to puppet/systemd 3.x

This bump is driven by simp/simp-core#829