### PR TITLE
Add a [Install] for puppet_agent.timer (#186)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Wed Aug 7 2024 Sean Peterson <wipeters@gmail.com> - 8.7.2
+* Wed Aug 07 2024 Sean Peterson <wipeters@gmail.com> - 8.7.2
 - Add a [Install] for puppet_agent.timer (#186)
 
 * Wed Jan 17 2024 Richard Gardner <rick@sicura.us> - 8.7.1

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Aug 7 2024 Sean Peterson <wipeters@gmail.com> - 8.7.2
+- Add a [Install] for puppet_agent.timer (#186)
+
 * Wed Jan 17 2024 Richard Gardner <rick@sicura.us> - 8.7.1
 - Updated hiera.yaml facts to support puppet 8
 

--- a/manifests/agent/cron.pp
+++ b/manifests/agent/cron.pp
@@ -214,6 +214,9 @@ class pupmod::agent::cron (
   $_timer = @("EOM")
   [Timer]
   OnCalendar=${_systemd_calendar}
+
+  [Install]
+  WantedBy=timers.target
   | EOM
 
   $_service = @("EOM")

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pupmod",
-  "version": "8.7.1",
+  "version": "8.7.2",
   "author": "SIMP Team",
   "summary": "A puppet module to manage puppetserver and puppet agents",
   "license": "Apache-2.0",


### PR DESCRIPTION
The puppet_agent.timer systemd unit does not restart after a system reboots. The timer will restart when it is linked to timers.target.