### PR TITLE
[puppetsync] Support simp-iptables 7.x

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Sep 13 2024 Steven Pritchard <steve@sicura.us> - 8.8.0
+- [puppetsync] Update module dependencies to support simp-iptables 7.x
+
 * Wed Aug 07 2024 Sean Peterson <wipeters@gmail.com> - 8.7.2
 - Add a [Install] for puppet_agent.timer (#186)
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pupmod",
-  "version": "8.7.2",
+  "version": "8.8.0",
   "author": "SIMP Team",
   "summary": "A puppet module to manage puppetserver and puppet agents",
   "license": "Apache-2.0",
@@ -19,7 +19,7 @@
   "dependencies": [
     {
       "name": "puppet/systemd",
-      "version_requirement": ">= 4.0.2 < 7.0.0"
+      "version_requirement": ">= 4.0.2 < 8.0.0"
     },
     {
       "name": "simp/haveged",
@@ -35,11 +35,11 @@
     },
     {
       "name": "puppetlabs/puppet_authorization",
-      "version_requirement": ">= 0.2.0 < 1.0.0"
+      "version_requirement": ">= 0.2.0 < 2.0.0"
     },
     {
       "name": "puppetlabs/hocon",
-      "version_requirement": ">= 0.9.3 < 2.0.0"
+      "version_requirement": ">= 0.9.3 < 3.0.0"
     },
     {
       "name": "puppetlabs/concat",
@@ -47,7 +47,7 @@
     },
     {
       "name": "simp/iptables",
-      "version_requirement": ">= 6.5.3 < 7.0.0"
+      "version_requirement": ">= 6.5.3 < 8.0.0"
     },
     {
       "name": "simp/simplib",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -100,7 +100,6 @@ RSpec.configure do |c|
   c.mock_with :rspec
 
   c.module_path = File.join(fixture_path, 'modules')
-  c.manifest_dir = File.join(fixture_path, 'manifests') if c.respond_to?(:manifest_dir)
 
   c.hiera_config = File.join(fixture_path, 'hieradata', 'hiera.yaml')
 


### PR DESCRIPTION
Update module dependencies to support simp-iptables 7.x.