### PR TITLE
Add agent_package parameter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Jun 09 2025 Steven Pritchard <steve@sicura.us> - 8.9.0
+- Add a `agent_package` parameter to allow using something other
+  than `puppet-agent` (#192)
+
 * Mon Jun 09 2025 Steven Pritchard <steve@sicura.us> - 8.8.2
 - Support puppet-systemd 8.x
 - Clean up for rubocop

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -95,6 +95,7 @@ The following parameters are available in the `pupmod` class:
 * [`mock`](#-pupmod--mock)
 * [`firewall`](#-pupmod--firewall)
 * [`pe_classlist`](#-pupmod--pe_classlist)
+* [`agent_package`](#-pupmod--agent_package)
 * [`package_ensure`](#-pupmod--package_ensure)
 * [`set_environment`](#-pupmod--set_environment)
 
@@ -418,11 +419,19 @@ Hash of pe classes and assorted metadata.
 
 Default value: `{}`
 
+##### <a name="-pupmod--agent_package"></a>`agent_package`
+
+Data type: `String[1]`
+
+The name of the agent package to install.
+
+Default value: `'puppet-agent'`
+
 ##### <a name="-pupmod--package_ensure"></a>`package_ensure`
 
 Data type: `String[1]`
 
-String used to specify 'latest', 'installed', or a specific version of the puppet-agent package
+String used to specify 'latest', 'installed', or a specific version of the agent package
 
 Default value: `simplib::lookup('simp_options::package_ensure' , { 'default_value' => 'installed'})`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -160,8 +160,11 @@
 # @param pe_classlist
 #   Hash of pe classes and assorted metadata.
 #
+# @param agent_package
+#   The name of the agent package to install.
+#
 # @param package_ensure
-#   String used to specify 'latest', 'installed', or a specific version of the puppet-agent package
+#   String used to specify 'latest', 'installed', or a specific version of the agent package
 #
 # @param set_environment
 #   Set the environment on the system to the currently running environment
@@ -208,6 +211,7 @@ class pupmod (
   Boolean                                      $fips                 = simplib::lookup('simp_options::fips', { 'default_value' => false }),
   Boolean                                      $firewall             = simplib::lookup('simp_options::firewall', { 'default_value' => false }),
   Hash                                         $pe_classlist         = {},
+  String[1]                                    $agent_package        = 'puppet-agent',
   String[1]                                    $package_ensure       = simplib::lookup('simp_options::package_ensure' , { 'default_value' => 'installed'}),
   Variant[Boolean, Enum['no_clean']]           $set_environment      = false,
   Boolean                                      $manage_facter_conf   = false,
@@ -231,7 +235,7 @@ class pupmod (
     if $enable_puppet_master {
       include 'pupmod::master'
     }
-    package { 'puppet-agent': ensure => $package_ensure }
+    package { $agent_package: ensure => $package_ensure }
 
     if $daemonize {
       $_puppet_service_ensure = 'running'

--- a/manifests/master/simp_auth.pp
+++ b/manifests/master/simp_auth.pp
@@ -113,7 +113,7 @@ class pupmod::master::simp_auth (
     notify               => Class['pupmod::master::service'],
   }
 
-  # The puppet-agent package drops off this file for some reason, and it comes
+  # The agent package drops off this file for some reason, and it comes
   # as root:root. The puppetserver attempts to read this file because it exists,
   # and can't because of the permissions (puppetserver runs as puppet:puppet).
   # Back it up to preserve custom content on upgrade, and blow it away.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pupmod",
-  "version": "8.8.2",
+  "version": "8.9.0",
   "author": "SIMP Team",
   "summary": "A puppet module to manage puppetserver and puppet agents",
   "license": "Apache-2.0",

--- a/spec/classes/20_classes/init_spec.rb
+++ b/spec/classes/20_classes/init_spec.rb
@@ -230,6 +230,13 @@ describe 'pupmod' do
               it { is_expected.to contain_class('haveged') }
             end
 
+            context 'with agent_package => openvox-agent' do
+              let(:params) { { agent_package: 'openvox-agent' } }
+
+              it { is_expected.to contain_package('openvox-agent').with_ensure('installed') }
+              it { is_expected.not_to contain_package('puppet-agent') }
+            end
+
             context 'with enable_puppet_master => false' do
               let(:params) { { enable_puppet_master: true, } }
 

--- a/templates/etc/puppetserver/conf.d/puppetserver.conf.epp
+++ b/templates/etc/puppetserver/conf.d/puppetserver.conf.epp
@@ -3,7 +3,7 @@
 
 # configuration for the JRuby interpreters
 jruby-puppet: {
-    # Where the puppet-agent dependency places puppet, facter, etc...
+    # Where the agent package dependency places puppet, facter, etc...
     # Puppet server expects to load Puppet from this location
     ruby-load-path: [/opt/puppetlabs/puppet/lib/ruby/vendor_ruby]
 


### PR DESCRIPTION
This should allow users to install `openvox-agent` instead of `puppet-agent`.

Fixes #192