### PR TITLE
(#161) Add agent install_options and clean up agent cron on daemonize

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Wed Jun 10 2026 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 11.1.0
+- Added `pupmod::agent_package_install_options` to pass install_options
+  through to the agent package resource (#161)
+- When `daemonize` is true, ensure the puppetagent cron entry, the
+  puppet_agent.timer, and the puppetagent_cron.sh and
+  careful_puppet_service_shutdown.sh helper scripts are absent (#161)
+
 * Sat Jun 06 2026 Steven Pritchard <steve@sicura.us> - 11.0.1
 - Additional cleanup for rubocop
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -102,6 +102,7 @@ The following parameters are available in the `pupmod` class:
 * [`firewall`](#-pupmod--firewall)
 * [`pe_classlist`](#-pupmod--pe_classlist)
 * [`agent_package`](#-pupmod--agent_package)
+* [`agent_package_install_options`](#-pupmod--agent_package_install_options)
 * [`package_ensure`](#-pupmod--package_ensure)
 * [`set_environment`](#-pupmod--set_environment)
 
@@ -471,6 +472,16 @@ The name of the agent package to install.
 
 Default value: `'openvox-agent'`
 
+##### <a name="-pupmod--agent_package_install_options"></a>`agent_package_install_options`
+
+Data type: `Optional[Array[Variant[String[1], Hash]]]`
+
+An array of install options passed to the agent package provider.
+See the Puppet `package` resource `install_options` attribute for the
+provider-specific format.
+
+Default value: `undef`
+
 ##### <a name="-pupmod--package_ensure"></a>`package_ensure`
 
 Data type: `String[1]`
@@ -737,6 +748,7 @@ The following parameters are available in the `pupmod::agent::install` class:
 
 * [`package_name`](#-pupmod--agent--install--package_name)
 * [`package_ensure`](#-pupmod--agent--install--package_ensure)
+* [`install_options`](#-pupmod--agent--install--install_options)
 
 ##### <a name="-pupmod--agent--install--package_name"></a>`package_name`
 
@@ -753,6 +765,14 @@ Data type: `String[1]`
 Should be set to installed, latest, or a specific version
 
 Default value: `pick(getvar('pupmod::package_ensure'), 'installed')`
+
+##### <a name="-pupmod--agent--install--install_options"></a>`install_options`
+
+Data type: `Optional[Array[Variant[String[1], Hash]]]`
+
+Options that get passed to the package provider
+
+Default value: `$pupmod::agent_package_install_options`
 
 ### <a name="pupmod--facter--conf"></a>`pupmod::facter::conf`
 

--- a/manifests/agent/install.pp
+++ b/manifests/agent/install.pp
@@ -4,13 +4,17 @@
 #   The name of the agent package to be installed
 # @param package_ensure
 #   Should be set to installed, latest, or a specific version
+# @param install_options
+#   Options that get passed to the package provider
 class pupmod::agent::install (
-  String[1] $package_name = $pupmod::agent_package,
-  String[1] $package_ensure = pick(getvar('pupmod::package_ensure'), 'installed')
+  String[1]                                 $package_name    = $pupmod::agent_package,
+  String[1]                                 $package_ensure  = pick(getvar('pupmod::package_ensure'), 'installed'),
+  Optional[Array[Variant[String[1], Hash]]] $install_options = $pupmod::agent_package_install_options,
 ) {
   assert_private()
 
   package { $package_name:
-    ensure => $package_ensure,
+    ensure          => $package_ensure,
+    install_options => $install_options,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -180,6 +180,11 @@
 # @param agent_package
 #   The name of the agent package to install.
 #
+# @param agent_package_install_options
+#   An array of install options passed to the agent package provider.
+#   See the Puppet `package` resource `install_options` attribute for the
+#   provider-specific format.
+#
 # @param package_ensure
 #   String used to specify 'latest', 'installed', or a specific version of the agent package
 #
@@ -222,6 +227,7 @@ class pupmod (
   Boolean                                                  $firewall             = simplib::lookup('simp_options::firewall', { 'default_value' => false }),
   Hash                                                     $pe_classlist         = {},
   String[1]                                                $agent_package        = 'openvox-agent',
+  Optional[Array[Variant[String[1], Hash]]]                $agent_package_install_options = undef,
   String[1]                                                $package_ensure       = simplib::lookup('simp_options::package_ensure' , { 'default_value' => 'installed' }),
   Variant[Boolean, Enum['no_clean']]                       $set_environment      = false,
   Boolean                                                  $manage_facter_conf   = false,
@@ -261,12 +267,16 @@ class pupmod (
 
     if $daemonize {
       $_puppet_service_ensure = 'running'
+      cron { 'puppetagent': ensure => 'absent' }
+      systemd::timer { 'puppet_agent.timer': ensure => 'absent' }
+      file { ['/usr/local/bin/puppetagent_cron.sh', '/usr/local/bin/careful_puppet_service_shutdown.sh']:
+        ensure => 'absent',
+      }
     }
     else {
       $_puppet_service_ensure = 'stopped'
+      include 'pupmod::agent::cron'
     }
-
-    include 'pupmod::agent::cron'
 
     service { 'puppet':
       ensure     => $_puppet_service_ensure,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pupmod",
-  "version": "11.0.1",
+  "version": "11.1.0",
   "author": "SIMP Team",
   "summary": "A puppet module to manage puppetserver and puppet agents",
   "license": "Apache-2.0",

--- a/spec/classes/20_classes/init_spec.rb
+++ b/spec/classes/20_classes/init_spec.rb
@@ -246,7 +246,11 @@ describe 'pupmod' do
             context 'with daemonize enabled' do
               let(:params) { { daemonize: true } }
 
-              it { is_expected.to contain_class('pupmod::agent::cron') }
+              it { is_expected.not_to contain_class('pupmod::agent::cron') }
+              it { is_expected.to contain_cron('puppetagent').with_ensure('absent') }
+              it { is_expected.to contain_systemd__timer('puppet_agent.timer').with_ensure('absent') }
+              it { is_expected.to contain_file('/usr/local/bin/puppetagent_cron.sh').with_ensure('absent') }
+              it { is_expected.to contain_file('/usr/local/bin/careful_puppet_service_shutdown.sh').with_ensure('absent') }
               it {
                 is_expected.to contain_service('puppet').with(
                   'ensure'     => 'running',
@@ -254,6 +258,17 @@ describe 'pupmod' do
                   'hasrestart' => true,
                   'hasstatus'  => true,
                   'subscribe'  => 'File[/etc/puppetlabs/puppet/puppet.conf]',
+                )
+              }
+            end
+
+            context 'with agent_package_install_options set' do
+              let(:params) { { agent_package_install_options: ['--enablerepo=foo', { '--setopt' => 'protect=1' }] } }
+
+              it {
+                is_expected.to contain_package('openvox-agent').with(
+                  'ensure'          => 'installed',
+                  'install_options' => ['--enablerepo=foo', { '--setopt' => 'protect=1' }],
                 )
               }
             end


### PR DESCRIPTION
- Add `pupmod::agent_package_install_options` to pass install_options through to the agent package resource.
- When `daemonize` is true, ensure the puppetagent cron entry, the puppet_agent.timer, and the puppetagent_cron.sh and careful_puppet_service_shutdown.sh helper scripts are absent so that toggling daemonize back on fully reverts the cron-based setup.